### PR TITLE
Replace `join_table` with `join_model`

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -63,21 +63,22 @@ class BaseMixin(object):
     def is_owned_by(self, user):
         raise NotImplementedError("Ownership logic is application-specific")
 
+
 Base = declarative_base(cls=BaseMixin)
 
 
-def join_table(joined_name, model_1, model_2, column_1=None, column_2=None,
-               fk_1='id', fk_2='id', metadata=Base.metadata):
+def join_model(join_table, model_1, model_2, column_1=None, column_2=None,
+               fk_1='id', fk_2='id', base=Base):
     """Helper function to create a join table for a many-to-many relationship.
 
     Parameters
     ----------
-    joined_name : str
+    join_table : str
         Name of the new table to be created.
     model_1 : str
         First model in the relationship.
-    table_2 : str
-        First model in the relationship.
+    model_2 : str
+        Second model in the relationship.
     column_1 : str, optional
         Name of the join table column corresponding to `model_1`. If `None`,
         then {`table1`[:-1]_id} will be used (e.g., `user_id` for `users`).
@@ -88,29 +89,36 @@ def join_table(joined_name, model_1, model_2, column_1=None, column_2=None,
         Name of the column from `model_1` that the foreign key should refer to.
     fk_2 : str, optional
         Name of the column from `model_2` that the foreign key should refer to.
-    metadata : sqlalchemy.sql.schema.MetaData
-        SQLAlchemy ORM schema to which the new table will be added.
+    base : sqlalchemy.ext.declarative.api.DeclarativeMeta
+        SQLAlchemy model base to subclass.
 
     Returns
     -------
-    sa.Table
-        SQLAlchemy ORM table object.
+    sqlalchemy.ext.declarative.api.DeclarativeMeta
+        SQLAlchemy association model class
     """
     table_1 = model_1.__tablename__
     table_2 = model_2.__tablename__
-
     if column_1 is None:
         column_1 = f'{table_1[:-1]}_id'
     if column_2 is None:
         column_2 = f'{table_2[:-1]}_id'
 
-    return sa.Table(joined_name, metadata,
-                    sa.Column(column_1, sa.ForeignKey(f'{table_1}.{fk_1}',
-                                                      ondelete='CASCADE'),
-                              primary_key=True),
-                    sa.Column(column_2, sa.ForeignKey(f'{table_2}.{fk_2}',
-                                                      ondelete='CASCADE'),
-                              primary_key=True))
+    model_attrs = {
+        '__tablename__': join_table,
+        'id': None,
+        column_1: sa.Column(column_1, sa.ForeignKey(f'{table_1}.{fk_1}',
+                                                    ondelete='CASCADE'),
+                            primary_key=True),
+        column_2: sa.Column(column_2, sa.ForeignKey(f'{table_2}.{fk_2}',
+                                                    ondelete='CASCADE'),
+                            primary_key=True),
+        model_1.__name__.lower(): relationship(model_1, cascade='all'),
+        model_2.__name__.lower(): relationship(model_2, cascade='all')
+    }
+    model = type(model_1.__name__ + model_2.__name__, (base,), model_attrs)
+
+    return model
 
 
 class ACL(Base):
@@ -122,12 +130,12 @@ class ACL(Base):
 class Role(Base):
     id = sa.Column(sa.String, nullable=False, primary_key=True)
     acls = relationship('ACL', secondary='role_acls', back_populates='roles',
-                         cascade='all')
+                        cascade='all')
     users = relationship('User', secondary='user_roles', back_populates='roles',
                          cascade='all')
 
 
-role_acls = join_table('role_acls', Role, ACL)
+RoleACL = join_model('role_acls', Role, ACL)
 
 
 class User(Base):
@@ -150,4 +158,4 @@ class User(Base):
         return True
 
 
-user_roles = join_table('user_roles', User, Role)
+UserRole = join_model('user_roles', User, Role)


### PR DESCRIPTION
Now returns a proper ORM model instead of an `sa.Table` object.