### PR TITLE
Refactor supervisor to receive flags

### DIFF
--- a/conf/supervisor/app.conf
+++ b/conf/supervisor/app.conf
@@ -1,8 +1,0 @@
-[include]
-files = common.conf
-
-[program:app]
-command=/usr/bin/env python baselayer/services/app.py
-environment=PYTHONPATH=".",PYTHONUNBUFFERED=1
-stdout_logfile=log/app.log
-redirect_stderr=true

--- a/conf/supervisor/debug.conf
+++ b/conf/supervisor/debug.conf
@@ -1,8 +1,0 @@
-[include]
-files = common.conf
-
-[program:app]
-command=/usr/bin/env python baselayer/services/app.py --debug
-environment=PYTHONPATH=".",PYTHONUNBUFFERED=1
-stdout_logfile=log/app.log
-redirect_stderr=true

--- a/conf/supervisor/supervisor.conf
+++ b/conf/supervisor/supervisor.conf
@@ -25,11 +25,17 @@ stdout_logfile=log/webpack.log
 redirect_stderr=true
 
 [program:fakeoauth2]
-command=/usr/bin/env python baselayer/services/fake_oauth2.py
+command=/usr/bin/env python baselayer/services/fake_oauth2.py %(ENV_FLAGS)s
 environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
 stdout_logfile=log/fake_oauth2.log
 redirect_stderr=true
 ## End development baselayer/services
+
+[program:app]
+command=/usr/bin/env python baselayer/services/app.py %(ENV_FLAGS)s
+environment=PYTHONPATH=".",PYTHONUNBUFFERED=1
+stdout_logfile=log/app.log
+redirect_stderr=true
 
 [program:nginx]
 command=nginx -c baselayer/conf/nginx.conf -p . -g "daemon off;"

--- a/conf/supervisor/testing.conf
+++ b/conf/supervisor/testing.conf
@@ -1,8 +1,0 @@
-[include]
-files = common.conf
-
-[program:app]
-command=/usr/bin/env python baselayer/services/app.py --config config.yaml.example --config _test_config.yaml
-environment=PYTHONPATH=".",PYTHONUNBUFFERED=1
-stdout_logfile=log/app.log
-redirect_stderr=true

--- a/tools/supervisor_status.py
+++ b/tools/supervisor_status.py
@@ -7,10 +7,13 @@ from os.path import join as pjoin
 
 base_dir = os.path.abspath(pjoin(os.path.dirname(__file__), '../..'))
 
+
 def supervisor_status():
-    result = subprocess.run('supervisorctl -c baselayer/conf/supervisor/common.conf status',
-                            shell=True, cwd=base_dir, check=True,
-                            stdout=subprocess.PIPE)
+    result = subprocess.run(
+        'supervisorctl -c baselayer/conf/supervisor/supervisor.conf status',
+        shell=True, cwd=base_dir, check=True,
+        stdout=subprocess.PIPE
+    )
     return result.stdout.split(b'\n')[:-1]
 
 

--- a/tools/watch_logs.py
+++ b/tools/watch_logs.py
@@ -63,14 +63,12 @@ def colorize(s, fg=None, bg=None, bold=False, underline=False, reverse=False):
     return style_start + s + style_end
 
 
-
 @contextlib.contextmanager
 def nostdout():
     save_stdout = sys.stdout
     sys.stdout = io.StringIO()
     yield
     sys.stdout = save_stdout
-
 
 
 def logs_from_config(supervisor_conf):
@@ -87,9 +85,7 @@ def logs_from_config(supervisor_conf):
 
 basedir = pjoin(os.path.dirname(__file__), '..')
 logdir = '../log'
-watched = logs_from_config(pjoin(basedir, 'conf/supervisor/common.conf'))
-watched.extend(logs_from_config(pjoin(basedir, 'conf/supervisor/app.conf')))
-
+watched = logs_from_config(pjoin(basedir, 'conf/supervisor/supervisor.conf'))
 
 sys.path.insert(0, basedir)
 
@@ -109,7 +105,7 @@ def tail_f(filename, interval=1.0):
         except IOError:
             time.sleep(1)
 
-    #Find the size of the file and move to the end
+    # Find the size of the file and move to the end
     st_results = os.stat(filename)
     st_size = st_results[6]
     f.seek(st_size)
@@ -135,8 +131,10 @@ def print_log(filename, color):
 
 
 colors = ['default', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'red']
-threads = [threading.Thread(target=print_log, args=(logfile, colors[n % len(colors)])) for
-           (n, logfile) in enumerate(watched)]
+threads = [
+    threading.Thread(target=print_log, args=(logfile, colors[n % len(colors)]))
+    for (n, logfile) in enumerate(watched)
+]
 
 for t in threads:
     t.start()


### PR DESCRIPTION
Previously, we had separate configurations for the standard/debug
versions of each service.  Now, the $FLAGS environment variable is
sent to the services that require options instead.

Supervisor cannot handle non-existent environment variables, so
you *have* to specify FLAGS, even if it is empty.  This is addressed
in the Makefile, by modifying the supervisord script to be `FLAGS=$(FLAGS)
supervisord` instead, so that it reuses any existing FLAGS definition,
or defines it as empty otherwise.

This change will necessitate modifications to Cesium and others
relying on baselayer.