### PR TITLE
Always use multi-user mode

### DIFF
--- a/app/app_server.py
+++ b/app/app_server.py
@@ -21,7 +21,7 @@ settings = {
 
     # Python Social Auth configuration
     'SOCIAL_AUTH_USER_MODEL': 'baselayer.app.models.User',
-    'SOCIAL_AUTH_STORAGE': 'baselayer.app.psa.TornadoStorage',
+    'SOCIAL_AUTH_STORAGE': 'social_tornado.models.TornadoStorage',
     'SOCIAL_AUTH_STRATEGY': 'social_tornado.strategy.TornadoStrategy',
     'SOCIAL_AUTH_AUTHENTICATION_BACKENDS': (
         'social_core.backends.google.GoogleOAuth2',

--- a/app/psa.py
+++ b/app/psa.py
@@ -4,18 +4,11 @@ Python Social Auth: storage and user model definitions
 https://github.com/python-social-auth
 """
 
-from social_sqlalchemy.storage import (SQLAlchemyUserMixin,
-                                       SQLAlchemyAssociationMixin,
-                                       SQLAlchemyNonceMixin,
-                                       SQLAlchemyCodeMixin,
-                                       SQLAlchemyPartialMixin,
-                                       BaseSQLAlchemyStorage)
-from social_tornado.models import TornadoStorage, init_social
+from social_tornado.models import init_social
 from social_core.backends.google import GoogleOAuth2
 
-import sqlalchemy as sa
-from sqlalchemy.orm import relationship
-from .models import Base, User, DBSession
+from .models import Base, DBSession
+
 
 class FakeGoogleOAuth2(GoogleOAuth2):
     AUTHORIZATION_URL = 'http://localhost:63000/fakeoauth2/auth'

--- a/conf/supervisor/supervisor.conf
+++ b/conf/supervisor/supervisor.conf
@@ -25,7 +25,7 @@ stdout_logfile=log/webpack.log
 redirect_stderr=true
 
 [program:fakeoauth2]
-command=/usr/bin/env python baselayer/services/fake_oauth2.py %(ENV_FLAGS)s
+command=/usr/bin/env python baselayer/services/fake_oauth2.py
 environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
 stdout_logfile=log/fake_oauth2.log
 redirect_stderr=true

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -19,7 +19,6 @@ database:
 
 server:
     url: http://localhost:5000
-    multi_user: False
 
     # From https://console.developers.google.com/
     #


### PR DESCRIPTION
This prevents problems with a user being created in single-user
mode (no Python Social Auth entry), and the same username then logging
in later under multi-user mode, creating a new profile.