### PR TITLE
Refactor config loading into (environment + config) loading

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,0 @@
-from .config import load_config, Config

--- a/app/app_server.py
+++ b/app/app_server.py
@@ -10,8 +10,8 @@ from .handlers import (
     LogoutHandler
 )
 
-from .config import load_config
-cfg = load_config()
+from .env import load_env
+env, cfg = load_env()
 
 
 # Tornado settings
@@ -39,6 +39,11 @@ settings = {
     'SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET': \
         cfg['server:auth:google_oauth2_secret'],
 }
+
+if cfg['server:auth:debug_login']:
+    settings['SOCIAL_AUTH_AUTHENTICATION_BACKENDS'] = (
+        'baselayer.app.psa.FakeGoogleOAuth2',
+    )
 
 handlers = SOCIAL_AUTH_ROUTES + [
     (r'/socket_auth_token', SocketAuthTokenHandler),

--- a/app/config.py
+++ b/app/config.py
@@ -64,21 +64,19 @@ class Config(dict):
         print("=" * 78)
 
 
-def load_config(config_files=None):
+def load_config(config_files=[]):
     basedir = Path(os.path.dirname(__file__))/'..'
-    if config_files is None:
-        config_files = []
+    missing = [cfg for cfg in config_files if not os.path.isfile(cfg)]
+    if missing:
+        raise RuntimeError(f"[Baselayer] Missing config files: {missing}")
 
     # Always load the default configuration values first, and override
     # with values in user configuration files
     all_configs = [Path(basedir/'config.yaml.example'),
                    Path(basedir/'../config.yaml.example')] + config_files
+    all_configs = [cfg for cfg in all_configs if os.path.isfile(cfg)]
     all_configs = [os.path.abspath(Path(c).absolute()) for c in all_configs]
 
     cfg = Config(all_configs)
-
-    missing = [cfg for cfg in config_files if not os.path.isfile(cfg)]
-    for m in missing:
-        print(f'[baselayer] Specified config file {m} missing')
 
     return cfg

--- a/app/env.py
+++ b/app/env.py
@@ -1,0 +1,30 @@
+"""
+Parse environment flags, and load the app configuration.
+"""
+
+import argparse
+
+from .config import load_config
+
+
+def load_env():
+    """Parse environment and load configuration.
+
+    Environment variables supported:
+
+    --config  Additional configuration files to load, over and above the
+              default  `baselayer/config.yaml.example`
+              and `./config.yaml.example`).  Can be specified multiple times.
+
+    --debug   In Debug mode:
+              a) Tornado reloads files automatically that change from disk.
+              b) SQLAlchemy logs more verbosely to the logs.
+    """
+    parser = argparse.ArgumentParser(description='Launch web app')
+    parser.add_argument('--config', action='append')
+    parser.add_argument('--debug', action='store_true')
+
+    env, unknown = parser.parse_known_args()
+    cfg = load_config(config_files=env.config)
+
+    return env, cfg

--- a/app/env.py
+++ b/app/env.py
@@ -25,6 +25,6 @@ def load_env():
     parser.add_argument('--debug', action='store_true')
 
     env, unknown = parser.parse_known_args()
-    cfg = load_config(config_files=env.config)
+    cfg = load_config(config_files=env.config or [])
 
     return env, cfg

--- a/services/app.py
+++ b/services/app.py
@@ -6,33 +6,21 @@ from zmq.eventloop import ioloop
 from baselayer.app.config import load_config
 from baselayer.app.app_server import (handlers as baselayer_handlers,
                                       settings as baselayer_settings)
+from baselayer.app.env import load_env
 
 import tornado.log
 
 ioloop.install()
 
-parser = argparse.ArgumentParser(description='Launch webapp')
-parser.add_argument('--config', action='append')
-parser.add_argument('--debug', action='store_true')
-args = parser.parse_args()
-
-cfg = load_config()
-if args.config:
-    for config in args.config:
-        cfg.update_from(config)
+env, cfg = load_env()
 
 app_factory = cfg['app:factory']
 baselayer_settings['cookie_secret'] = cfg['app:secret-key']
-baselayer_settings['autoreload'] = args.debug
-if args.debug:
+baselayer_settings['autoreload'] = env.debug
+if env.debug:
     import logging
     logging.basicConfig()
     logging.getLogger('sqlalchemy.engine').setLevel(logging.INFO)
-
-if cfg['server:auth:debug_login']:
-    baselayer_settings['SOCIAL_AUTH_AUTHENTICATION_BACKENDS'] = (
-        'baselayer.app.psa.FakeGoogleOAuth2',
-    )
 
 module, app_factory = app_factory.rsplit('.', 1)
 app_factory = getattr(importlib.import_module(module), app_factory)

--- a/tools/db_init.py
+++ b/tools/db_init.py
@@ -2,22 +2,21 @@
 
 import subprocess
 import sys
-import glob
-import os
 import argparse
 import textwrap
-from baselayer.app.config import load_config
+from baselayer.app.env import load_env
 
 from status import status
 
 
-parser = argparse.ArgumentParser(description='Create or re-create the database.')
+parser = argparse.ArgumentParser(
+    description='Create or re-create the database.'
+)
 parser.add_argument('-f', '--force', action='store_true',
                     help='recreate the db, even if it already exists')
-args = parser.parse_args()
+args, unknown = parser.parse_known_args()
 
-
-cfg = load_config()
+env, cfg = load_env()
 
 db = cfg['database:database']
 all_dbs = (db, db + '_test')
@@ -40,6 +39,7 @@ def run(cmd):
                           stdout=subprocess.PIPE,
                           stderr=subprocess.PIPE,
                           shell=True)
+
 
 def test_db(database):
     test_cmd = f"psql {flags} -c 'SELECT 0;' {database}"

--- a/tools/env_summary.py
+++ b/tools/env_summary.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from baselayer.app.env import load_env
+
+env, cfg = load_env()
+
+print('=' * 50)
+print(f"Server at: {cfg['server:url']}")
+print(f"Database at: \
+{cfg['database:host']}:{cfg['database:port']} ({cfg['database:database']})")
+print(f"Fake OAuth: \
+{'enabled' if cfg['server:auth:debug_login'] else 'disabled'}")
+print(f"Debug mode: \
+{'enabled' if env.debug else 'disabled'}")
+
+print('=' * 50)


### PR DESCRIPTION
- The environment (command line flags) determine which configuration
  to load.  Everywhere where the configuration is loaded, the
  environment should be examined as well.  As such, these two
  operations have been combined.

- Factoring out the config+env loader allows us to print the
  environment after launching the server, so that users know which URL
  to connect to, e.g.

- The refactor also simplifies `services/app` (which should be fairly
  minimal), and moves some of its logic to `baselayer/app/app_server`
  instead.