### PR TITLE
Let Fake OAuth2 self-discover the server path

### DIFF
--- a/app/psa.py
+++ b/app/psa.py
@@ -11,8 +11,13 @@ from .models import Base, DBSession
 
 
 class FakeGoogleOAuth2(GoogleOAuth2):
-    AUTHORIZATION_URL = 'http://localhost:63000/fakeoauth2/auth'
-    ACCESS_TOKEN_URL = 'http://localhost:63000/fakeoauth2/token'
+    @property
+    def AUTHORIZATION_URL(self):
+        return self.strategy.absolute_uri('/fakeoauth2/auth')
+
+    @property
+    def ACCESS_TOKEN_URL(self):
+        return self.strategy.absolute_uri('/fakeoauth2/token')
 
     def user_data(self, access_token, *args, **kwargs):
         return {

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -9,6 +9,10 @@ http {
     server localhost:64000;
   }
 
+  upstream fakeoauth_server {
+    server localhost:63000;
+  }
+
   # See http://nginx.org/en/docs/http/websocket.html
   map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -40,6 +44,10 @@ http {
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
         proxy_read_timeout 60s;
+    }
+
+    location /fakeoauth2 {
+        proxy_pass http://fakeoauth_server;
     }
 
     error_log log/nginx-error.log warn;

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -18,8 +18,6 @@ database:
     password:
 
 server:
-    url: http://localhost:5000
-
     # From https://console.developers.google.com/
     #
     # - Create Client ID


### PR DESCRIPTION
Now, we no longer have to provide the server path in the configuration
file, and that authentication will work both when accessing the server
via localhost or a public DNS name.

1. Configure nginx to pass requests for `/fakeoauth2/*` to the
   microservice, running on port 63000.  This means the authentication
   URLs becomes `/fakeoauth2/{auth,token}`.

2. Python Social Auth's OAuth2 backends all require absolute redirect
   URLs.  Fortunately, the backend Strategy (Tornado, in our case),
   provide a method, `absolute_path`, to convert relative to absolute
   paths.