### PR TITLE
Correctly route OAuth2 requests to FakeOAuth2 server

### DIFF
--- a/conf/nginx.conf.template
+++ b/conf/nginx.conf.template
@@ -50,7 +50,7 @@ http {
     }
 
     location /fakeoauth2 {
-        proxy_pass http://fakeoauth_server;
+        proxy_pass http://fakeoauth_server/fakeoauth2;
     }
 
     error_log log/nginx-error.log warn;


### PR DESCRIPTION
Previously, we tried to verify OAuth2 credentials by posting to the
same URL as used by the browser + `/fakeoauth2/token`.  The token
request is made internally (from the web browser), resulting in
problems when hosting via Docker.

For example, the browser may point to `http://localhost:9000` because
Docker remaps 5000 -> 9000.  But from inside the Docker
container (where the server runs), the FakeOAuth URL remains
`http://localhost:5000/fakeoauth2` (not 9000).

The workaround here is to connect directly to the hosted port of the
service (default 63000).