### PR TITLE
Launch WebPack as required by server mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,13 +57,16 @@ run: paths dependencies fill_conf_values
 	echo && \
 	$(SUPERVISORD)
 
-run_production: paths dependencies fill_conf_values bundle
+run_production: paths fill_conf_values
+	@echo
+	@echo "[!] Production run: not automatically installing dependencies."
+	@echo
 	export FLAGS="--config config.yaml" && \
 	cd .. && \
 	$(ENV_SUMMARY) && \
 	$(SUPERVISORD)
 
-run_testing: paths dependencies fill_conf_values bundle
+run_testing: paths dependencies fill_conf_values
 	export FLAGS="--config test_config.yaml" && \
 	cd .. && \
 	$(ENV_SUMMARY) && \

--- a/services/webpack.py
+++ b/services/webpack.py
@@ -4,21 +4,34 @@ from baselayer.app.env import load_env
 import subprocess
 import sys
 import time
+import os
+from pathlib import Path
 
 env, cfg = load_env()
 
-if env.debug:
-    print("[service/webpack]: debug mode detected, launching")
-    p = subprocess.Popen(
-        ['./node_modules/.bin/webpack', '--watch'],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE
-    )
-    for line in p.stdout:
-        print(line.decode(), end="")
-        sys.stdout.flush()
-else:
-    print("[service/webpack]: not in debug mode, exiting")
+bundle = Path(os.path.dirname(__file__))/'../../static/build/bundle.js'
 
+def run(cmd):
+    p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    for line in p.stdout:
+        print(f'[service/webpack] {line.decode()}', end="")
+        sys.stdout.flush()
+    return p
+
+if env.debug:
+    print("[service/webpack]: debug mode detected, launching webpack monitor")
+    p = run(['./node_modules/.bin/webpack', '--watch'])
+    sys.exit(p.returncode)
+
+elif bundle.is_file():
+    print("[service/webpack]: bundle.js already built, exiting")
     # Run for a few seconds so that supervisor knows the service was
     # successful
     time.sleep(3)
+    sys.exit(0)
+
+else:
+    print("[service/webpack]: bundle.js not found, building")
+    p = run(['./node_modules/.bin/webpack'])
+    time.sleep(1)
+    sys.exit(p.returncode)

--- a/tools/supervisor_status.py
+++ b/tools/supervisor_status.py
@@ -18,4 +18,4 @@ def supervisor_status():
 
 
 if __name__ == '__main__':
-    sys.stdout.buffer.write('\n'.join(supervisor_status()) + '\n')
+    print('\n'.join(supervisor_status()))


### PR DESCRIPTION
1. If in production mode, launch webpack only if `bundle.js` is missing.
2. When in debug mode, launch the webpack monitor (changes to .js
   files are automatically re-bundled).

Closes #24 