### PR TITLE
Fix fake authentication with newer versions of Python Social Auth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ before_install:
   - source .travis/travis_funcs.sh
 
 install:
+  # Workaround for invalid GPG keys for MongoDB, CouchDB, and git-lfs
+  - sudo rm -f /etc/apt/sources.list.d/mongodb*
+  - sudo rm -f /etc/apt/sources.list.d/couchdb*
+  - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 762E3157
   - .travis/travis_install.sh
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ addons:
     - supervisor
     - nginx
     - xvfb
-    - chromium-browser
     - unzip
     - libnss3
     - libgconf-2-4
@@ -73,7 +72,6 @@ before_install:
   - ccache -s
   - export PATH=/usr/lib/ccache:${PATH}
   - which python; python --version
-  - wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
   - source .travis/travis_funcs.sh
 
 install:

--- a/app/psa.py
+++ b/app/psa.py
@@ -42,7 +42,7 @@ class FakeGoogleOAuth2(GoogleOAuth2):
     def user_data(self, access_token, *args, **kwargs):
         return {
             'id': 'testuser@cesium-ml.org',
-            'emails': [{'value': 'testuser@cesium-ml.org', 'type': 'home'}]
+            'email': 'testuser@cesium-ml.org'
         }
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,8 +9,8 @@ requests
 selenium>=3.12.0
 pytest
 sqlalchemy
-social-auth-core
-social-auth-app-tornado
-social-auth-storage-sqlalchemy
+social-auth-core>=3.0.0
+social-auth-app-tornado>=1.0.0
+social-auth-storage-sqlalchemy>=1.1.0
 selenium-requests
 arrow==0.13.0


### PR DESCRIPTION
The way Python Social Auth gets email addresses from OAuth2 responses
has changed, due to
python-social-auth/social-core@d77d75547b9ada3460a1b6809c8c9ad854f76871