### PR TITLE
Try serving files statically via Nginx before reaching out to backend Python server

### DIFF
--- a/.travis/travis_install.sh
+++ b/.travis/travis_install.sh
@@ -30,7 +30,7 @@ make db_init
 section_end "init.baselayer"
 
 section "install.geckodriver.and.selenium"
-GECKO_VER=0.24.0
+GECKO_VER=0.26.0
 wget https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VER}/geckodriver-v${GECKO_VER}-linux64.tar.gz
 sudo tar -xzf geckodriver-v${GECKO_VER}-linux64.tar.gz -C /usr/local/bin
 rm geckodriver-v${GECKO_VER}-linux64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,8 @@ webpack = npx webpack
 
 .PHONY: clean dependencies db_init db_clear bundle bundle-watch paths
 .PHONY: fill_conf_values log run run_production run_testing monitor attach
-.PHONY: stop status test_headless test check-js-updates lint-install
-.PHONY: lint lint-unix lint-githook baselayer_doc_reqs html
+.PHONY: stop status test_headless test test-nginx-config check-js-updates
+.PHONY: lint-install lint lint-unix lint-githook baselayer_doc_reqs html
 
 help:
 	@python ./baselayer/tools/makefile_to_help.py $(MAKEFILE_LIST)
@@ -130,6 +130,11 @@ test: ## Run tests.
 test: paths dependencies fill_conf_values
 	@PYTHONPATH='.' ./baselayer/tools/test_frontend.py
 
+test-nginx-config: ## Check nginx configuration.
+	@PWD=$(shell pwd); \
+	echo $(PWD) ; \
+	nginx -t -p $(PWD) -c baselayer/conf/nginx.conf 2>&1 | grep -v "could not open error log"
+
 # Call this target to see which Javascript dependencies are not up to date
 check-js-updates:
 	./baselayer/tools/check_js_updates.sh
@@ -140,7 +145,7 @@ lint-install: cp-lint-yaml lint-githook
 	@echo "Installing latest version of ESLint and AirBNB style rules"
 	@./baselayer/tools/update_eslint.sh
 
-cp-lint-yaml: ## Copy eslint config file to parent app if not present
+cp-lint-yaml: # Copy eslint config file to parent app if not present
 	@if ! [ -e .eslintrc.yaml ]; then \
 	  echo "No ESLint configuration found; copying baselayer's version of .eslintrc.yaml"; \
 	  cp baselayer/.eslintrc.yaml .eslintrc.yaml; \

--- a/conf/nginx.conf.template
+++ b/conf/nginx.conf.template
@@ -13,6 +13,10 @@ http {
     server localhost:{{ ports.fake_oauth }};
   }
 
+  upstream backend {
+    server 127.0.0.1:{{ ports.app_internal }};
+  }
+
   # See http://nginx.org/en/docs/http/websocket.html
   map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -32,8 +36,15 @@ http {
     listen {{ ports.app_http_proxy }} proxy_protocol; # This is for AWS Elastic Load Balancer
     client_max_body_size 10M;
 
+    root static;  # Relative to the launch path, typically the root of the repo
     location / {
-      proxy_pass http://127.0.0.1:{{ ports.app_internal }};
+      # Try to serve files directly, before hitting Tornado backend
+      # See https://www.nginx.com/resources/wiki/start/topics/tutorials/config_pitfalls/
+      try_files $uri $uri/ @proxy;
+    }
+
+    location @proxy {
+      proxy_pass http://backend;
 
       proxy_set_header        Host $http_host;
       proxy_set_header        X-Real-IP $remote_addr;


### PR DESCRIPTION
    Prefer static serving of files through NGINX
    
    NGINX will now check for the existence of a static file, before
    requesting a page from the backend server.
    
    Also made small tweaks to the config so that the root URL is specified
    similar to the websocket and auth endpoints.
