### PR TITLE
keep track of when db-mapped entities are modified

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import sessionmaker, scoped_session, relationship
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy import func
 
 from .json_util import to_json
 from .custom_exceptions import AccessError
@@ -32,6 +33,7 @@ class BaseMixin(object):
     query = DBSession.query_property()
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
+    modified = sa.Column(sa.DateTime, default=func.now(), onupdate=func.current_timestamp())
 
     @declared_attr
     def __tablename__(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,8 @@ class BaseMixin(object):
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
     modified = sa.Column(sa.DateTime, default=func.now(),
-                         onupdate=func.current_timestamp())
+                         onupdate=func.current_timestamp(),
+                         nullable=False)
 
     @declared_attr
     def __tablename__(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -33,7 +33,8 @@ class BaseMixin(object):
     query = DBSession.query_property()
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
-    modified = sa.Column(sa.DateTime, default=func.now(), onupdate=func.current_timestamp())
+    modified = sa.Column(sa.DateTime, default=func.now(),
+                         onupdate=func.current_timestamp())
 
     @declared_attr
     def __tablename__(cls):


### PR DESCRIPTION
I added a column to `models.Base` that keeps track of when any ORM-mapped entity is modified. This will complement the `created_at` field for keeping track of the provenance of objects and data.