### PR TITLE
Enable batch mode on DB

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -20,7 +20,7 @@ class Config(dict):
         dict.__init__(self)
         if config_files is not None:
             cwd = os.getcwd()
-            config_names = [Path(c).relative_to(cwd) for c in config_files]
+            config_names = [Path(c) for c in config_files]
             print(f'  Config files: {config_names[0]}')
             for f in config_names[1:]:
                 print(f'                {f}')

--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,8 @@ class BaseMixin(object):
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
     modified = sa.Column(sa.DateTime, default=func.now(),
-                         onupdate=func.current_timestamp())
+                         onupdate=func.current_timestamp(),
+                         nullable=True)
 
     @declared_attr
     def __tablename__(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import sessionmaker, scoped_session, relationship
 from sqlalchemy.orm.exc import NoResultFound
+from sqlalchemy import func
 
 from .json_util import to_json
 from .custom_exceptions import AccessError
@@ -32,6 +33,7 @@ class BaseMixin(object):
     query = DBSession.query_property()
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
+    modified = sa.Column(sa.DateTime, default=func.now(), onupdate=func.current_timestamp())
 
     @declared_attr
     def __tablename__(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -34,8 +34,7 @@ class BaseMixin(object):
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
     modified = sa.Column(sa.DateTime, default=func.now(),
-                         onupdate=func.current_timestamp(),
-                         nullable=False)
+                         onupdate=func.current_timestamp())
 
     @declared_attr
     def __tablename__(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -21,7 +21,7 @@ def init_db(user, database, password=None, host=None, port=None):
     url = 'postgresql://{}:{}@{}:{}/{}'
     url = url.format(user, password or '', host or '', port or '', database)
 
-    conn = sa.create_engine(url, client_encoding='utf8')
+    conn = sa.create_engine(url, client_encoding='utf8', use_batch_mode=True)
 
     DBSession.configure(bind=conn)
     Base.metadata.bind = conn

--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,8 @@ class BaseMixin(object):
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
     modified = sa.Column(sa.DateTime, default=func.now(),
-                         onupdate=func.current_timestamp())
+                         onupdate=func.current_timestamp(),
+                         nullable=False)
 
     @declared_attr
     def __tablename__(cls):

--- a/app/models.py
+++ b/app/models.py
@@ -21,7 +21,7 @@ def init_db(user, database, password=None, host=None, port=None):
     url = 'postgresql://{}:{}@{}:{}/{}'
     url = url.format(user, password or '', host or '', port or '', database)
 
-    conn = sa.create_engine(url, client_encoding='utf8', use_batch_mode=True)
+    conn = sa.create_engine(url, client_encoding='utf8')
 
     DBSession.configure(bind=conn)
     Base.metadata.bind = conn
@@ -32,9 +32,9 @@ def init_db(user, database, password=None, host=None, port=None):
 class BaseMixin(object):
     query = DBSession.query_property()
     id = sa.Column(sa.Integer, primary_key=True)
-    created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
+    created_at = sa.Column(sa.DateTime, nullable=False, default=func.now())
     modified = sa.Column(sa.DateTime, default=func.now(),
-                         onupdate=func.current_timestamp(),
+                         onupdate=func.now(),
                          nullable=True)
 
     @declared_attr

--- a/app/models.py
+++ b/app/models.py
@@ -33,7 +33,8 @@ class BaseMixin(object):
     query = DBSession.query_property()
     id = sa.Column(sa.Integer, primary_key=True)
     created_at = sa.Column(sa.DateTime, nullable=False, default=datetime.now)
-    modified = sa.Column(sa.DateTime, default=func.now(), onupdate=func.current_timestamp())
+    modified = sa.Column(sa.DateTime, default=func.now(),
+                         onupdate=func.current_timestamp())
 
     @declared_attr
     def __tablename__(cls):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psycopg2-binary==2.7.3.2
+psycopg2-binary==2.7.6.1
 pyyaml
 tornado==4.5.3
 pyzmq


### PR DESCRIPTION
Psycopg2 Batch Mode (Fast Execution)
Modern versions of psycopg2 include a feature known as Fast Execution Helpers , which have been shown in benchmarking to improve psycopg2’s executemany() performance with INSERTS by multiple orders of magnitude. SQLAlchemy allows this extension to be used for all executemany() style calls invoked by an Engine when used with multiple parameter sets, by adding the use_batch_mode flag to create_engine():

engine = create_engine(
    "postgresql+psycopg2://scott:tiger@host/dbname",
    use_batch_mode=True)
Batch mode is considered to be experimental at this time, however may be enabled by default in a future release.

See also

Executing Multiple Statements - demonstrates how to use DBAPI executemany() with the Connection object.

New in version 1.2.0.