### PR TITLE
Set FLAGS to config.yaml for all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,9 @@ ESLINT=npx eslint
 
 .DEFAULT_GOAL := help
 
-FLAGS += "--config=config.yaml"
+# Use `config.yaml` by default, unless overridden by user
+# through setting FLAGS environment variable
+FLAGS:=$(if $(FLAGS),$(FLAGS),"--config=config.yaml")
 
 # Bold
 B=\033[1m

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ ESLINT=npx eslint
 
 .DEFAULT_GOAL := help
 
+FLAGS += "--config=config.yaml"
+
 # Bold
 B=\033[1m
 # Normal
@@ -77,7 +79,6 @@ run: paths dependencies fill_conf_values
 	$(SUPERVISORD)
 
 run_production: ## Run the web application in production mode (no dependency checking).
-run_production: FLAGS = "--config=config.yaml"  # both this and the next FLAGS definition are needed
 run_production: paths fill_conf_values
 	@echo "[!] Production run: not automatically installing dependencies."
 	@echo

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -41,3 +41,12 @@
 ## Launch
 
 Launch the app with `make run`.
+
+## Deployment options
+
+The default configuration file used can be overridden by setting the
+FLAGS environment variable:
+
+```
+FLAGS="--config=myconfig.yaml" make run
+```


### PR DESCRIPTION
This allows FLAGS to be extended from the outside, so you can do, e.g.:

```
FLAGS="--config=foo.yaml" make run
```

We never fully supported this use case before, relying on `config.yaml` to be the default configuration.