### PR TITLE
Install supervisord from pip

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+supervisor>=4
 psycopg2-binary
 pyyaml
 tornado==6.0.3

--- a/tools/check_app_environment.py
+++ b/tools/check_app_environment.py
@@ -25,11 +25,6 @@ deps = {
         # It must be >= 1.7
         '1.7'
     ),
-    'supervisord': (
-        ['supervisord', '-v'],
-        lambda v: v,
-        '3.0b2'
-    ),
     'psql': (
         ['psql', '--version'],
         lambda v: v.split()[2],


### PR DESCRIPTION
Previously, because supervisord only ran on Python 2, we required the
user to install it separately.  Now that it is available for Python 3,
automatically install it when necessary.