### PR TITLE
Ignore exceptions raised by supervisor_status

### DIFF
--- a/tools/supervisor_status.py
+++ b/tools/supervisor_status.py
@@ -9,6 +9,9 @@ base_dir = os.path.abspath(pjoin(os.path.dirname(__file__), '../..'))
 
 
 def supervisor_status():
+    """
+    Raises CalledProcessError if supervisorctl exits with non-zero status
+    """
     result = subprocess.run(
         'python -m supervisor.supervisorctl -c baselayer/conf/supervisor/supervisor.conf status',
         shell=True, cwd=base_dir, check=True,

--- a/tools/test_frontend.py
+++ b/tools/test_frontend.py
@@ -6,7 +6,6 @@ import pathlib
 import requests
 import sys
 import signal
-import socket
 import subprocess
 import time
 
@@ -36,8 +35,11 @@ def all_services_running():
     other statuses (STARTING, STOPPED, etc.) are present.
     """
     valid_states = ('RUNNING', 'EXITED')
-    return all([any(state in line for state in valid_states)
-                for line in supervisor_status()])
+    try:
+        return all([any(state in line for state in valid_states)
+                    for line in supervisor_status()])
+    except subprocess.CalledProcessError:
+        return False
 
 
 def verify_server_availability(url, timeout=60):


### PR DESCRIPTION
There are various reasons why these occur: the socket doesn't yet exist,
etc.  But we don't really care: we just want to know if the services are
up and running.