### PR TITLE
Refactor MessageHandler

### DIFF
--- a/static/js/MessageHandler.js
+++ b/static/js/MessageHandler.js
@@ -1,19 +1,42 @@
+/* Handle incoming websocket messages */
+
 import { SHOW_NOTIFICATION, showNotification } from './components/Notifications';
 
 class MessageHandler {
-  constructor(dispatch, handler) {
-    this.dispatch = dispatch;
-    this.handle = message => {
-      switch (message.action) {
-        case SHOW_NOTIFICATION:
-          this.dispatch(showNotification(message.payload.note,
-                                         message.payload.type));
-          break;
-        default:
-          handler(message);
-      }
-    };
+  /* You have to run `init` before the messageHandler can be used */
+
+  constructor() {
+    this._handlers = [];
+    this._dispatch = null;
+    this._getState = null;
+  }
+
+  init(dispatch, getState) {
+    this._dispatch = dispatch;
+    this._getState = getState;
+  }
+
+  add(handler) {
+    this._handlers.push(handler);
+  }
+
+  handle(action, payload) {
+    // Execute all registered handlers on the incoming message
+    this._handlers.forEach((handler) => {
+      handler(action, payload, this._dispatch, this._getState);
+    });
   }
 }
 
-export default MessageHandler;
+const notificationHandler = (action, payload, dispatch) => {
+  if (action === SHOW_NOTIFICATION) {
+    const { note, type } = payload;
+    dispatch(showNotification(note, type));
+  }
+};
+
+
+const messageHandler = new MessageHandler();
+messageHandler.add(notificationHandler);
+
+export default messageHandler;

--- a/static/js/components/WebSocket.jsx
+++ b/static/js/components/WebSocket.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { createCookie, readCookie, eraseCookie } from '../cookies';
 import ReconnectingWebSocket from '../reconnecting-websocket';
-import MessageHandler from '../MessageHandler';
+import messageHandler, { MessageHandler } from '../MessageHandler';
 import { showNotification, hideNotificationByTag, MS_PER_YEAR } from './Notifications';
 
 
@@ -97,15 +97,15 @@ class WebSocket extends React.Component {
     };
 
     ws.onmessage = (event) => {
-      const message = event.data;
+      const data = event.data;
 
       // Ignore heartbeat signals
-      if (message === '<3') {
+      if (data === '<3') {
         return;
       }
 
-      const data = JSON.parse(message);
-      const action = data.action;
+      const message = JSON.parse(data);
+      const { action, payload } = message;
 
       switch (action) {
         case "AUTH REQUEST":
@@ -126,7 +126,7 @@ class WebSocket extends React.Component {
           this.props.dispatch(hideNotificationByTag(tag));
           break;
         default:
-          this.props.messageHandler.handle(data);
+          messageHandler.handle(action, payload);
       }
     };
 
@@ -182,7 +182,9 @@ class WebSocket extends React.Component {
 WebSocket.propTypes = {
   url: PropTypes.string.isRequired,
   auth_url: PropTypes.string.isRequired,
-  messageHandler: PropTypes.instanceOf(MessageHandler)
+  messageHandler: PropTypes.shape({
+    handle: PropTypes.func.isRequired
+  })
 };
 
 module.exports = WebSocket;


### PR DESCRIPTION
There is now a singleton `messageHandler` object.  To register a
handler, use `messageHandler.add(handler)`.  The handler should be a
function of the form:

```
(action, payload, dispatch, getState) => { ... }
```