### PR TITLE
Have get_if_owned_by return None if no obj w/ ID instead of erroring

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -57,9 +57,7 @@ class BaseMixin(object):
     def get_if_owned_by(cls, ident, user, options=[]):
         obj = cls.query.options(options).get(ident)
 
-        if obj is None:
-            raise AccessError(f'No such {cls.__name__}')
-        elif not obj.is_owned_by(user):
+        if obj is not None and not obj.is_owned_by(user):
             raise AccessError('Insufficient permissions.')
 
         return obj


### PR DESCRIPTION
Previously, if an ID was supplied to `Base.get_if_owned_by` that did not exist, an error was raised. This method should mirror the behavior of `query.get`, which returns `None` instead of erroring in that case. This PR makes `get_if_owned_by` return `None` if no matching ID exists, to match the behavior of `query.get`.