### PR TITLE
Fix supervisorctl monitoring of micro-services

### DIFF
--- a/tools/supervisor_status.py
+++ b/tools/supervisor_status.py
@@ -9,16 +9,25 @@ base_dir = os.path.abspath(pjoin(os.path.dirname(__file__), '../..'))
 
 
 def supervisor_status():
-    """
-    Raises CalledProcessError if supervisorctl exits with non-zero status
+    """Check status of all services.
+
+    Returns
+    -------
+    list
+        The output lines from ``supervisorctl``.
+    int
+        Return code of ``supervisorctl``.  This will be 0 for all
+        services running, or 3 if one of them exited (note: this is
+        expected when, e.g., webpack exits normally).
     """
     result = subprocess.run(
         'python -m supervisor.supervisorctl -c baselayer/conf/supervisor/supervisor.conf status',
-        shell=True, cwd=base_dir, check=True,
+        shell=True, cwd=base_dir,
         stdout=subprocess.PIPE
     )
-    return result.stdout.decode().split('\n')[:-1]
+    return result.stdout.decode().split('\n')[:-1], result.returncode
 
 
 if __name__ == '__main__':
-    print('\n'.join(supervisor_status()))
+    supervisor_output, _ = supervisor_status()
+    print('\n'.join(supervisor_output))


### PR DESCRIPTION
Supervisor 4 introduces an error code on exited services
(https://github.com/Supervisor/supervisor/issues/1223).

The internal function that calls supervisorctl has been modified to
return the output as well as the error code. When the error code is 3,
we now proceed as though the operation was successful (which, typicall,
it was).