### PR TITLE
Require that browser send cookies only for this site

### DIFF
--- a/static/js/cookies.js
+++ b/static/js/cookies.js
@@ -7,7 +7,7 @@ export function createCookie(name, value, minutes) {
     date.setTime(date.getTime() + (minutes * 60 * 1000));
     expires = `; expires=${date.toGMTString()}`;
   }
-  document.cookie = `${name}=${value}${expires}; path=/`;
+  document.cookie = `${name}=${value}${expires};path=/;SameSite=Strict`;
 }
 
 export function readCookie(name) {


### PR DESCRIPTION
Soon, Firefox will start rejecting cookies that don't have either
SameSite or Secure set.  See also:

  https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#SameSite_cookies