### PR TITLE
Add a newline to the end of compiled templates

### DIFF
--- a/tools/fill_conf_values.py
+++ b/tools/fill_conf_values.py
@@ -25,6 +25,7 @@ def fill_config_file_values(template_paths):
 
             with open(os.path.splitext(template_path)[0], 'w') as f:
                 f.write(rendered)
+                f.write('\n')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is necessary for compiled JSX files to pass lint validation