### PR TITLE
use executemany_mode = values

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -14,7 +14,7 @@ from .custom_exceptions import AccessError
 
 
 DBSession = scoped_session(sessionmaker())
-EXECUTEMANY_PAGESIZE = 10000
+EXECUTEMANY_PAGESIZE = 50000
 
 
 # The db has to be initialized later; this is done by the app itself

--- a/app/models.py
+++ b/app/models.py
@@ -14,6 +14,7 @@ from .custom_exceptions import AccessError
 
 
 DBSession = scoped_session(sessionmaker())
+EXECUTEMANY_PAGESIZE = 10000
 
 
 # The db has to be initialized later; this is done by the app itself
@@ -22,7 +23,9 @@ def init_db(user, database, password=None, host=None, port=None):
     url = 'postgresql://{}:{}@{}:{}/{}'
     url = url.format(user, password or '', host or '', port or '', database)
 
-    conn = sa.create_engine(url, client_encoding='utf8')
+    conn = sa.create_engine(url, client_encoding='utf8',
+                            executemany_mode='values',
+                            executemany_values_page_size=EXECUTEMANY_PAGESIZE)
 
     DBSession.configure(bind=conn)
     Base.metadata.bind = conn

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ simplejson
 requests
 selenium>=3.12.0
 pytest==4.3.1
-sqlalchemy==1.2.18
+sqlalchemy==1.3.7
 social-auth-core>=3.0.0
 social-auth-app-tornado>=1.0.0
 social-auth-storage-sqlalchemy>=1.1.0


### PR DESCRIPTION
This PR is a companion to skyportal/skyportal#517 and is a dependency of that PR. 

This PR:

   * bumps sqlalchemy to 1.3.7 to make use of `executemany_mode = 'values'` (https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#psycopg2-fast-execution-helpers)

   * Sets a global `EXECUTEMANY_PAGESIZE` parameter which determines how many VALUES tuples to bundle into a single insert, I set it to the default of 10k 