### PR TITLE
Add new makefile target test_xml to generate py.test report for BuildPulse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,6 +132,10 @@ test: ## Run tests.
 test: paths dependencies fill_conf_values
 	@PYTHONPATH='.' ./baselayer/tools/test_frontend.py
 
+test_xml: ## Run tests and generate JUnit XML output.
+test_xml: paths dependencies fill_conf_values
+	@PYTHONPATH='.' ./baselayer/tools/test_frontend.py --xml
+
 # Call this target to see which Javascript dependencies are not up to date
 check-js-updates:
 	./baselayer/tools/check_js_updates.sh

--- a/tools/test_frontend.py
+++ b/tools/test_frontend.py
@@ -72,7 +72,7 @@ if __name__ == '__main__':
     from argparse import ArgumentParser
     parser = ArgumentParser()
     parser.add_argument('test_spec', nargs='?', default=None,
-                        help='''Test spec. Example: 
+                        help='''Test spec. Example:
     test_frontend.py skyportal/tests/api
 ''')
     parser.add_argument('--xml', action='store_true')


### PR DESCRIPTION
This PR adds a new `Makefile` target, `make test_xml`, to generate a py.test report that can be used to track test flakiness on BuildPulse. `make test_xml` runs `tools/test_frontend.py` with a new `--xml` flag, which tells `test_frontend.py` to pass `--junitxml=../../test-results/junit.xml` to `py.test`.  This stores the test results in a manner that can be read and parsed by BuildPulse. 