### PR TITLE
Expose parser so utilities can use it

### DIFF
--- a/app/env.py
+++ b/app/env.py
@@ -9,6 +9,10 @@ from .config import load_config
 # Cache loading of environment
 _cache = {}
 
+parser = argparse.ArgumentParser(description='Launch web app')
+parser.add_argument('-C', '--config', action='append')
+parser.add_argument('--debug', action='store_true')
+
 
 def load_env():
     """Parse environment and load configuration.
@@ -28,13 +32,11 @@ def load_env():
 
     """
     if not _cache:
-        parser = argparse.ArgumentParser(description='Launch web app')
-        parser.add_argument('-C', '--config', action='append')
-        parser.add_argument('--debug', action='store_true')
-
         env, unknown = parser.parse_known_args()
         cfg = load_config(config_files=env.config or [])
 
-        _cache.update({'file': env.config, 'env': env, 'cfg': cfg})
+        _cache.update({'file': env.config,
+                       'env': env,
+                       'cfg': cfg})
 
     return _cache['env'], _cache['cfg']


### PR DESCRIPTION
Utilities that use `load_env` may also want to add their own command
line arguments.  Having access to the parser allows them to do so.