### PR TITLE
Make dbinit more robust and provide helpful feedback

### DIFF
--- a/tools/db_init.py
+++ b/tools/db_init.py
@@ -39,50 +39,18 @@ if host:
 if port:
     flags += f' -p {port}'
 
+test_cmd = f"{psql_cmd} {flags} -c 'SELECT 0;' "
+
 
 def run(cmd):
     return subprocess.run(cmd,
-                          stdout=subprocess.PIPE,
-                          stderr=subprocess.PIPE,
+                          capture_output=True,
                           shell=True)
 
 
 def test_db(database):
-    test_cmd = f"{psql_cmd} {flags} -c 'SELECT 0;' {database}"
-    p = run(test_cmd)
-
-    try:
-        with status('Testing database connection'):
-            if not p.returncode == 0:
-                raise RuntimeError()
-    except:
-        print(textwrap.dedent(
-            f'''
-             !!! Error accessing database:
-
-             The most common cause of database connection errors is a
-             misconfigured `pg_hba.conf`.
-
-             We tried to connect to the database with the following parameters:
-
-               database: {db}
-               username: {user}
-               host:     {host}
-               port:     {port}
-
-             The postgres client exited with the following error message:
-
-             {'-' * 78}
-             {p.stderr.decode('utf-8').strip()}
-             {'-' * 78}
-
-             Please modify your `pg_hba.conf`, and use the following command to
-             check your connection:
-
-               {test_cmd}
-            '''))
-
-        sys.exit(1)
+    p = run(test_cmd + database)
+    return (p.returncode == 0)
 
 
 plat = run('uname').stdout
@@ -107,17 +75,66 @@ if args.force:
                 p = run(f'{sudo} dropdb {current_db}')
                 if p.returncode != 0:
                     raise RuntimeError()
-    except:
+    except RuntimeError:
         print('Could not delete database: \n\n'
               f'{textwrap.indent(p.stderr.decode("utf-8").strip(), prefix="  ")}\n')
         sys.exit(1)
 
 with status(f'Creating databases'):
     for current_db in all_dbs:
-        run(f'{sudo} createdb -w {current_db}')
-        run(f'{sudo} createdb -w {current_db}')
-        run(f'psql {flags}\
+        # We allow this to fail, because oftentimes because of complicated db setups
+        # users want to create their own databases
+
+        if test_db(current_db):
+            continue
+
+        p = run(f'{sudo} createdb -w {current_db}')
+        if p.returncode == 0:
+            run(f'psql {flags}\
               -c "GRANT ALL PRIVILEGES ON DATABASE {current_db} TO {user};"\
               {current_db}')
+        else:
+            print()
+            print(f'Warning: could not create db {current_db}')
+            print()
+            print('\n'.join(line for line in p.stderr.decode('utf-8').split('\n') if 'ERROR' in line))
+            print()
+            print('  You should create it manually by invoking `createdb`.')
+            print('  Then, execute:')
+            print()
+            print(f'    psql {flags}'
+                  f' -c "GRANT ALL PRIVILEGES ON DATABASE {current_db} TO {user};"'
+                  f' {current_db}')
+            print()
 
-test_db(db)
+try:
+    with status('Testing database connection'):
+        if not test_db(db):
+            raise RuntimeError()
+except RuntimeError:
+    print(textwrap.dedent(
+        f'''
+         !!! Error accessing database:
+
+         The most common cause of database connection errors is a
+         misconfigured `pg_hba.conf`.
+
+         We tried to connect to the database with the following parameters:
+
+           database: {db}
+           username: {user}
+           host:     {host}
+           port:     {port}
+
+         The postgres client exited with the following error message:
+
+         {'-' * 78}
+         {p.stderr.decode('utf-8').strip()}
+         {'-' * 78}
+
+         Please modify your `pg_hba.conf`, and use the following command to
+         check your connection:
+
+           {test_cmd + database}
+        '''))
+    sys.exit(1)


### PR DESCRIPTION
- Before, we did not fail when db already existed.  Now, there is an
  explicit check for that.  We also don't try and recreate an existing
  database.
- Explain to the user how to create a DB and permissions if our
  creation didn't work.  System configurations can be complex, so we
  cannot expect to succeed always.