### PR TITLE
Run multiple server processes via supervisord

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,6 @@ doc/_build
 # These are built from templates
 conf/supervisor/supervisor.conf
 services/dask/supervisor.conf
+services/app/supervisor.conf
+services/nginx/nginx.conf
 conf/nginx.conf

--- a/app/env.py
+++ b/app/env.py
@@ -3,6 +3,7 @@ Parse environment flags, and load the app configuration.
 """
 
 import argparse
+import textwrap
 
 from .config import load_config
 
@@ -36,5 +37,16 @@ def load_env():
         cfg = load_config(config_files=env.config or [])
 
         _cache.update({'file': env.config, 'env': env, 'cfg': cfg})
+
+        # Prohibit more arguments from being added on after config has
+        # been loaded
+        def no_more_args(cls, *args, **kwargs):
+            raise RuntimeError(textwrap.dedent('''
+                Trying to add argument after `load_env` has already been called.
+                This typically happens when one of your imports calls
+                `load_env`.  To avoid this error, move your imports until after
+                adding new arguments to the parser.
+            '''))
+        parser.add_argument = no_more_args
 
     return _cache['env'], _cache['cfg']

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -19,6 +19,9 @@ paths:
     downloads_folder: '/tmp'
 
 server:
+    ssl: False
+    processes: 1
+
     # From https://console.developers.google.com/
     #
     # - Create Client ID
@@ -26,11 +29,11 @@ server:
     # - Authorized redirect URLs: http://localhost:5000/complete/google-oauth2/
     #
     # You need to have Google+ API enabled; it takes a few minutes to activate.
-    ssl: False
     auth:
         debug_login: False
         google_oauth2_key:
         google_oauth2_secret:
+
 
 services:
     paths:

--- a/services/app/supervisor.conf
+++ b/services/app/supervisor.conf
@@ -1,5 +1,0 @@
-[program:app]
-command=/usr/bin/env python baselayer/services/app/app.py %(ENV_FLAGS)s
-environment=PYTHONPATH=".",PYTHONUNBUFFERED=1
-stdout_logfile=log/app.log
-redirect_stderr=true

--- a/services/app/supervisor.conf.template
+++ b/services/app/supervisor.conf.template
@@ -1,0 +1,7 @@
+[program:app]
+numprocs={{ server.processes }}
+command=/usr/bin/env python baselayer/services/app/app.py --process=%(process_num)s %(ENV_FLAGS)s
+process_name=%(program_name)s_%(process_num)02d
+environment=PYTHONPATH=".",PYTHONUNBUFFERED=1
+stdout_logfile=log/app_%(process_num)02d.log
+redirect_stderr=true

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -13,6 +13,13 @@ http {
     server localhost:{{ ports.fake_oauth }};
   }
 
+  upstream frontends {
+    least_conn;
+    {% for p in range(server.processes) -%}
+      server 127.0.0.1:{{ ports.app_internal + p }};
+    {% endfor %}
+  }
+
   # See http://nginx.org/en/docs/http/websocket.html
   map $http_upgrade $connection_upgrade {
     default upgrade;
@@ -33,7 +40,7 @@ http {
     client_max_body_size 10M;
 
     location / {
-      proxy_pass http://127.0.0.1:{{ ports.app_internal }};
+      proxy_pass http://frontends;
 
       proxy_set_header        Host $http_host;
       proxy_set_header        X-Real-IP $remote_addr;

--- a/services/nginx/supervisor.conf
+++ b/services/nginx/supervisor.conf
@@ -1,2 +1,2 @@
 [program:nginx]
-command=nginx -c baselayer/conf/nginx.conf -p . -g "daemon off;"
+command=nginx -c baselayer/services/nginx/nginx.conf -p . -g "daemon off;"

--- a/tools/watch_logs.py
+++ b/tools/watch_logs.py
@@ -3,6 +3,7 @@
 
 import os
 import sys
+import glob
 from os.path import join as pjoin
 import contextlib
 import io
@@ -26,7 +27,10 @@ def logs_from_config(supervisor_conf):
         for line in f:
             if '_logfile=' in line:
                 _, logfile = line.strip().split('=')
-                watched.append(logfile)
+                if '%' in logfile:
+                    watched.extend(glob.glob(logfile.split('%')[0] + '*'))
+                else:
+                    watched.append(logfile)
 
     return watched
 


### PR DESCRIPTION
If `server.processes` is set to a number higher than 1,
run multiple Tornado servers via supervisord.

Each process runs on a separate port, and nginx directs requests
accordingly.  By default scheduling is round robin, but here we
selected scheduling by least number of active connections (see
https://docs.nginx.com/nginx/admin-guide/load-balancer/http-load-balancer/#choosing-a-load-balancing-method).