### PR TITLE
Always rebuild JS bundle upon launch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ ESLINT=npx eslint
 
 # Use `config.yaml` by default, unless overridden by user
 # through setting FLAGS environment variable
-FLAGS:=$(if $(FLAGS),$(FLAGS),"--config=config.yaml")
+FLAGS:=$(if $(FLAGS),$(FLAGS),--config=config.yaml)
 
 PYTHON=PYTHONPATH=. python
 ENV_SUMMARY=$(PYTHON) baselayer/tools/env_summary.py $(FLAGS)
@@ -100,11 +100,11 @@ run_production: ## Run the web application in production mode (no dependency che
 run_production: system_setup
 	@echo "[!] Production run: not automatically installing dependencies."
 	@echo
-	@export FLAGS="$(FLAGS)" && \
+	@export FLAGS="$(FLAGS) --production" && \
 	$(ENV_SUMMARY) && \
 	$(SUPERVISORD)
 
-run_testing: FLAGS = "--config=test_config.yaml"  # both this and the next FLAGS definition are needed
+run_testing: FLAGS = --config=test_config.yaml  # both this and the next FLAGS definition are needed
 run_testing: system_setup
 	@echo -e "\n$(B)[baselayer] Launch app for testing$(N)"
 	@export FLAGS=$(FLAGS) && \

--- a/services/webpack/webpack.py
+++ b/services/webpack/webpack.py
@@ -6,12 +6,12 @@ import time
 import os
 from pathlib import Path
 
-from baselayer.app.env import load_env
+from baselayer.app.env import load_env, parser
 from baselayer.log import make_log
 
-env, cfg = load_env()
+parser.description = 'Launch webpack microservice'
 
-bundle = Path(os.path.dirname(__file__)) / '../../static/build/main.bundle.js'
+env, cfg = load_env()
 
 log = make_log('service/webpack')
 
@@ -27,16 +27,7 @@ if env.debug:
     log("debug mode detected, launching webpack monitor")
     p = run(['npx', 'webpack', '--watch'])
     sys.exit(p.returncode)
-
-elif bundle.is_file():
-    log("main.bundle.js already built, exiting")
-    # Run for a few seconds so that supervisor knows the service was
-    # successful
-    time.sleep(3)
-    sys.exit(0)
-
 else:
-    log("main.bundle.js not found, building")
-    p = run(['npx', 'webpack'])
-    time.sleep(1)
+    log("Rebuilding main JavaScript bundle")
+    p = run(['npx', 'webpack', '--mode=production', '--devtool=none'])
     sys.exit(p.returncode)


### PR DESCRIPTION
This doesn't fix any bug (everything was working as expected, as far as I can tell—no rebuilds on production runs); but it should help @dima in that now the bundle will rebuild (in production mode) upon initial app launch via `make run_production`.