### PR TITLE
Ensure OAuth UID matches username

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -46,13 +46,17 @@ class PSABaseHandler(RequestHandler):
         if user_id and oauth_uid:
             user = User.query.get(int(user_id))
             sa = user.social_auth.first()
+            if sa is None:
+                # No SocialAuth entry; probably machine generated user
+                return user
             if (sa.uid.encode('utf-8') == oauth_uid):
                 return user
 
     def login_user(self, user):
-        sa = user.social_auth.first()
         self.set_secure_cookie('user_id', str(user.id))
-        self.set_secure_cookie('user_oauth_uid', sa.uid)
+        sa = user.social_auth.first()
+        if sa is not None:
+            self.set_secure_cookie('user_oauth_uid', sa.uid)
 
     def write_error(self, status_code, exc_info=None):
         if exc_info is not None:

--- a/app/psa.py
+++ b/app/psa.py
@@ -41,6 +41,8 @@ class FakeGoogleOAuth2(GoogleOAuth2):
     def user_data(self, access_token, *args, **kwargs):
         return {'id': 'testuser@cesium-ml.org', 'email': 'testuser@cesium-ml.org'}
 
+    def get_user_id(self, *args, **kwargs):
+        return 'testuser@cesium-ml.org'
 
 # Set up TornadoStorage
 init_social(Base, DBSession, {'SOCIAL_AUTH_USER_MODEL': 'baselayer.app.models.User'})


### PR DESCRIPTION
Currently, if a server gets re-deployed with a new database, previously
logged in users are able to access the system.  Often, their UIDs now
point to a new user, so they "log in" as this new person.

To address this, we now, in addition to user_id, set a cookie for OAuth
UID (Google email). When logging in, we check this cookie to
ensure that the user doesn't get logged into a different username.

The accompanying SkyPortal patch is https://github.com/skyportal/skyportal/pull/887