### PR TITLE
Add external logging as a supervisord microservice

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -60,6 +60,18 @@ ports:
     websocket_path_in: 'ipc://run/message_flow_in'
     websocket_path_out: 'ipc://run/message_flow_out'
 
+
+external_logging:
+    enabled: False
+    # get an account at https://papertrailapp.com
+    service_name: papertrail
+    # change url to the correct subdomain for your account
+    # and change the port as well
+    url: logX.papertrailapp.com
+    port: XX
+    # which log files, if any do you not want to send over to the 3rd party?
+    excluded_log_files: []
+
 # You can schedule jobs to run at a certain time interval (given in minutes).
 #
 # If baselayer is not running at the time the job is supposed to run,

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -63,15 +63,16 @@ ports:
 
 external_logging:
     enabled: False
-    # get an account at https://papertrailapp.com
     services:
-        - papertrail:
-            # change url to the correct subdomain for your account
-            # and change the port as well
-            url: logX.papertrailapp.com
-            port: XX
-            # which log files, if any do you not want to send over to the 3rd party?
-            excluded_log_files: []
+        papertrail:
+           # get an account at https://papertrailapp.com
+           enabled: False
+           # change url to the correct subdomain for your account
+           # and change the port as well
+           url: logX.papertrailapp.com
+           port: XX
+           # which log files, if any do you not want to send over to the 3rd party?
+           excluded_log_files: []
 
 # You can schedule jobs to run at a certain time interval (given in minutes).
 #

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -64,13 +64,14 @@ ports:
 external_logging:
     enabled: False
     # get an account at https://papertrailapp.com
-    service_name: papertrail
-    # change url to the correct subdomain for your account
-    # and change the port as well
-    url: logX.papertrailapp.com
-    port: XX
-    # which log files, if any do you not want to send over to the 3rd party?
-    excluded_log_files: []
+    services:
+        - papertrail:
+            # change url to the correct subdomain for your account
+            # and change the port as well
+            url: logX.papertrailapp.com
+            port: XX
+            # which log files, if any do you not want to send over to the 3rd party?
+            excluded_log_files: []
 
 # You can schedule jobs to run at a certain time interval (given in minutes).
 #

--- a/services/external_logging/external_logging.py
+++ b/services/external_logging/external_logging.py
@@ -1,13 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import os
-import sys
-import glob
-from os.path import join as pjoin
-import contextlib
-import io
-import time
 import threading
 import logging
 import socket
@@ -16,7 +9,7 @@ from logging.handlers import SysLogHandler
 from baselayer.log import make_log
 from baselayer.app.env import load_env
 from baselayer.tools.watch_logs import (
-    print_log, nostdout, logs_from_config, basedir, watched, tail_f
+    basedir, watched, tail_f
 )
 
 env, cfg = load_env()

--- a/services/external_logging/external_logging.py
+++ b/services/external_logging/external_logging.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import sys
+import glob
+from os.path import join as pjoin
+import contextlib
+import io
+import time
+import threading
+import logging
+import socket
+from logging.handlers import SysLogHandler
+
+from baselayer.log import make_log
+from baselayer.app.env import load_env
+from baselayer.tools.watch_logs import (
+    print_log, nostdout, logs_from_config, basedir, watched, tail_f
+)
+
+env, cfg = load_env()
+log = make_log("external_logging")
+
+
+def check_external_logging():
+    """
+    Check 3rd party logging, if enabled, and make sure that
+    it is set up properly
+
+    TODO: This could eventually be done with a JSONschema
+    """
+    enabled_services = []
+    external_logging_enabled = False
+
+    if not cfg.get('external_logging'):
+        return external_logging_enabled, enabled_services
+
+    external_logging_enabled = cfg['external_logging']["enabled"]
+    if not external_logging_enabled:
+        return external_logging_enabled, enabled_services
+
+    print(cfg['external_logging'])
+    for service, config in cfg['external_logging']["services"].items():
+        if service == 'papertrail':
+            if not config["enabled"]:
+                break
+            try:
+                if config["url"].find("papertrailapp.com") == -1:
+                    log("Warning: incorrect URL for papertrail logging.")
+                    break
+            except AttributeError:
+                log("Warning: missing URL for papertrail logging.")
+                break
+            try:
+                int(config["port"])
+            except (ValueError, TypeError):
+                log(
+                    "Warning: bad port"
+                    f" ({config['port']}) for papertrail logging."
+                    " Should be an integer."
+                )
+                break
+        log(f"Enabling external logging to {service}.")
+        enabled_services.append(service)
+
+    return external_logging_enabled, enabled_services
+
+
+def get_papertrail_stream_logger():
+
+    class ContextFilter(logging.Filter):
+        hostname = socket.gethostname()
+
+        def filter(self, record):
+            record.hostname = ContextFilter.hostname
+            return True
+
+    syslog = SysLogHandler(address=(
+        cfg['external_logging']["services"]["papertrail"]["url"],
+        cfg['external_logging']["services"]["papertrail"]["port"]
+    ))
+    syslog.addFilter(ContextFilter())
+    title = cfg['app'].get("title", basedir.split("/")[-1])
+    format = f'%(asctime)s %(hostname)s {title}: %(message)s'
+    formatter = logging.Formatter(format, datefmt='%b %d %H:%M:%S')
+    syslog.setFormatter(formatter)
+    logger = logging.getLogger()
+    logger.addHandler(syslog)
+    logger.setLevel(logging.INFO)
+    return logger
+
+
+def stream_log(filename, stream_logger):
+    stream_logger.info('-> ' + filename)
+    for line in tail_f(filename):
+        stream_logger.info(line)
+
+
+external_logging_enabled, enabled_services = check_external_logging()
+
+if external_logging_enabled:
+    # logging set up: see `https://documentation.solarwinds.com/en/
+    #   Success_Center/papertrail/Content/kb/configuration/
+    #   configuring-centralized-logging-from-python-apps.htm`
+    if "papertrail" in enabled_services:
+        stream_logger = get_papertrail_stream_logger()
+        excluded = cfg['external_logging']["services"]["papertrail"]["excluded_log_files"]
+        threads = [
+            threading.Thread(target=stream_log, args=(logfile, stream_logger))
+            for logfile in watched if logfile not in excluded
+        ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+else:
+    log("External logging disabled.")

--- a/services/external_logging/supervisor.conf
+++ b/services/external_logging/supervisor.conf
@@ -1,7 +1,5 @@
-[program:cron]
-command=/usr/bin/env python baselayer/services/cron/cron.py %(ENV_FLAGS)s
+[program:external_logging]
+command=/usr/bin/env python baselayer/services/external_logging/external_logging.py %(ENV_FLAGS)s
 environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
-startretries=0
-startsecs=1
-stdout_logfile=log/cron.log
+stdout_logfile=log/external_logging.log
 redirect_stderr=true

--- a/services/external_logging/supervisor.conf
+++ b/services/external_logging/supervisor.conf
@@ -1,0 +1,7 @@
+[program:cron]
+command=/usr/bin/env python baselayer/services/cron/cron.py %(ENV_FLAGS)s
+environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
+startretries=0
+startsecs=1
+stdout_logfile=log/cron.log
+redirect_stderr=true

--- a/tools/watch_logs.py
+++ b/tools/watch_logs.py
@@ -9,59 +9,7 @@ import contextlib
 import io
 import time
 import threading
-import logging
-import socket
-from logging.handlers import SysLogHandler
-
-from baselayer.log import (colorize, make_log)
-from baselayer.app.env import load_env
-
-env, cfg = load_env()
-log = make_log("watch_logs")
-
-
-def check_external_logging():
-    """
-    Check 3rd party logging, if enabled, and make sure that
-    it is set up properly
-
-    TODO: This could eventually be done with a JSONschema
-    """
-    enabled_services = []
-    external_logging_enabled = False
-
-    if not cfg.get('external_logging'):
-        return external_logging_enabled, enabled_services
-
-    external_logging_enabled = cfg['external_logging']["enabled"]
-    if not external_logging_enabled:
-        return external_logging_enabled, enabled_services
-
-    print(cfg['external_logging'])
-    for service, config in cfg['external_logging']["services"].items():
-        if service == 'papertrail':
-            if not config["enabled"]:
-                break
-            try:
-                if config["url"].find("papertrailapp.com") == -1:
-                    log("Warning: incorrect URL for papertrail logging.")
-                    break
-            except AttributeError:
-                log("Warning: missing URL for papertrail logging.")
-                break
-            try:
-                int(config["port"])
-            except (ValueError, TypeError):
-                log(
-                    "Warning: bad port"
-                    f" ({config['port']}) for papertrail logging."
-                    " Should be an integer."
-                )
-                break
-        log(f"Enabling external logging to {service}.")
-        enabled_services.append(service)
-
-    return external_logging_enabled, enabled_services
+from baselayer.log import colorize
 
 
 @contextlib.contextmanager
@@ -97,31 +45,6 @@ watched.append('log/error.log')
 watched.append('log/nginx-bad-access.log')
 watched.append('log/nginx-error.log')
 watched.append('log/fake_oauth2.log')
-watched.append('log/watch_logs.log')
-
-
-def get_papertrail_stream_logger():
-
-    class ContextFilter(logging.Filter):
-        hostname = socket.gethostname()
-
-        def filter(self, record):
-            record.hostname = ContextFilter.hostname
-            return True
-
-    syslog = SysLogHandler(address=(
-        cfg['external_logging']["services"]["papertrail"]["url"],
-        cfg['external_logging']["services"]["papertrail"]["port"]
-    ))
-    syslog.addFilter(ContextFilter())
-    title = cfg['app'].get("title", basedir.split("/")[-1])
-    format = f'%(asctime)s %(hostname)s {title}: %(message)s'
-    formatter = logging.Formatter(format, datefmt='%b %d %H:%M:%S')
-    syslog.setFormatter(formatter)
-    logger = logging.getLogger()
-    logger.addHandler(syslog)
-    logger.setLevel(logging.INFO)
-    return logger
 
 
 def tail_f(filename, interval=1.0):
@@ -149,12 +72,6 @@ def tail_f(filename, interval=1.0):
             yield line.rstrip('\n')
 
 
-def stream_log(filename, stream_logger):
-    stream_logger.info('-> ' + filename)
-    for line in tail_f(filename):
-        stream_logger.info(line)
-
-
 def print_log(filename, color):
     def print_col(line):
         print(colorize(line, fg=color))
@@ -165,29 +82,14 @@ def print_log(filename, color):
         print_col(line)
 
 
-colors = ['default', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'red']
-threads = [
-    threading.Thread(target=print_log, args=(logfile, colors[n % len(colors)]))
-    for (n, logfile) in enumerate(watched)
-]
+if __name__ == "__main__":
+    colors = ['default', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'red']
+    threads = [
+        threading.Thread(target=print_log, args=(logfile, colors[n % len(colors)]))
+        for (n, logfile) in enumerate(watched)
+    ]
 
-external_logging_enabled, enabled_services = check_external_logging()
-
-if external_logging_enabled:
-    # logging set up: see `https://documentation.solarwinds.com/en/
-    #   Success_Center/papertrail/Content/kb/configuration/
-    #   configuring-centralized-logging-from-python-apps.htm`
-    if "papertrail" in enabled_services:
-        stream_logger = get_papertrail_stream_logger()
-        excluded = cfg['external_logging']["services"]["papertrail"]["excluded_log_files"]
-        threads.extend([
-            threading.Thread(target=stream_log, args=(logfile, stream_logger))
-            for logfile in watched if logfile not in excluded
-        ])
-else:
-    log("External logging disabled.")
-
-for t in threads:
-    t.start()
-for t in threads:
-    t.join()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()

--- a/tools/watch_logs.py
+++ b/tools/watch_logs.py
@@ -10,6 +10,44 @@ import io
 import time
 import threading
 from baselayer.log import colorize
+import logging
+import socket
+from logging.handlers import SysLogHandler
+
+from app.env import load_env
+
+env, cfg = load_env()
+
+
+# check 3rd party logging, if enabled, and make sure that
+# it is set up properly
+if cfg.get('external_logging'):
+    external_logging_enabled = cfg['external_logging']["enabled"]
+    if external_logging_enabled:
+        if cfg['external_logging']['service_name'] != 'papertrail':
+            # we do not know how to do this yet
+            print(
+                "Warning: we only know how to use papertrail"
+                " for external logging"
+            )
+            external_logging_enabled = False
+        try:
+            if cfg['external_logging']["url"].find("papertrailapp.com") == -1:
+                print("Warning: incorrect URL for papertrail logging")
+                external_logging_enabled = False
+        except AttributeError:
+            print("Warning: missing URL for papertrail logging")
+            external_logging_enabled = False
+        try:
+            int(cfg['external_logging']["port"])
+        except (ValueError, TypeError):
+            print(
+                "Warning: bad port"
+                f" ({cfg['external_logging']['port']}) for papertrail logging"
+            )
+            external_logging_enabled = False
+else:
+    external_logging_enabled = False
 
 
 @contextlib.contextmanager
@@ -47,6 +85,29 @@ watched.append('log/nginx-error.log')
 watched.append('log/fake_oauth2.log')
 
 
+def get_stream_logger():
+
+    class ContextFilter(logging.Filter):
+        hostname = socket.gethostname()
+
+        def filter(self, record):
+            record.hostname = ContextFilter.hostname
+            return True
+
+    syslog = SysLogHandler(address=(
+        cfg['external_logging']["url"], cfg['external_logging']["port"]
+    ))
+    syslog.addFilter(ContextFilter())
+    title = cfg['app'].get("title", basedir.split("/")[-1])
+    format = f'%(asctime)s %(hostname)s {title}: %(message)s'
+    formatter = logging.Formatter(format, datefmt='%b %d %H:%M:%S')
+    syslog.setFormatter(formatter)
+    logger = logging.getLogger()
+    logger.addHandler(syslog)
+    logger.setLevel(logging.INFO)
+    return logger
+
+
 def tail_f(filename, interval=1.0):
     f = None
 
@@ -72,6 +133,12 @@ def tail_f(filename, interval=1.0):
             yield line.rstrip('\n')
 
 
+def stream_log(filename, stream_logger):
+    stream_logger.info('-> ' + filename)
+    for line in tail_f(filename):
+        stream_logger.info(line)
+
+
 def print_log(filename, color):
     def print_col(line):
         print(colorize(line, fg=color))
@@ -87,6 +154,18 @@ threads = [
     threading.Thread(target=print_log, args=(logfile, colors[n % len(colors)]))
     for (n, logfile) in enumerate(watched)
 ]
+
+if external_logging_enabled:
+    # logging set up: see `https://documentation.solarwinds.com/en/
+    #   Success_Center/papertrail/Content/kb/configuration/
+    #   configuring-centralized-logging-from-python-apps.htm`
+    stream_logger = get_stream_logger()
+    threads.extend([
+        threading.Thread(target=stream_log, args=(logfile, stream_logger))
+        for logfile in watched if watched not in cfg['external_logging']["excluded_log_files"]
+    ])
+else:
+    print("External logging disabled.")
 
 for t in threads:
     t.start()


### PR DESCRIPTION
This PR adds the capability of streaming a subset of logs to a 3rd party provider using `SysLogHandler` from the `logging` module of Python. Currently we use [papertrail](https://www.papertrail.com) which provides a free tier of 1-week log retention and alerting integration. External logging is established as a microservice. The (secret) parameters are set up in `config.yaml`:

```yaml
external_logging:
    enabled: False
    services:
        papertrail:
           # get an account at https://papertrailapp.com
           enabled: False
           # change url to the correct subdomain for your account
           # and change the port as well
           url: logX.papertrailapp.com
           port: XX
           # which log files, if any, do you not want to send over to the 3rd party?
           excluded_log_files: []
```