### PR TITLE
Expect external logging to exit quickly under certain conditions

### DIFF
--- a/services/external_logging/supervisor.conf
+++ b/services/external_logging/supervisor.conf
@@ -3,3 +3,4 @@ command=/usr/bin/env python baselayer/services/external_logging/external_logging
 environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
 stdout_logfile=log/external_logging.log
 redirect_stderr=true
+startsecs=0


### PR DESCRIPTION
If there are no external services configured, the logging service should
exit immediately. That, in turn, should not be interpreted as a service
failure.