### PR TITLE
Status server returns 503 (temp unavail) and serves all routes

### DIFF
--- a/services/status_server/status_server.py
+++ b/services/status_server/status_server.py
@@ -9,11 +9,12 @@ env, cfg = load_env()
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
+        self.set_status(503)
         self.write("<h2>SkyPortal is being provisioned</h2>")
 
 def make_app():
     return tornado.web.Application([
-        (r"/", MainHandler),
+        (r".*", MainHandler),
     ])
 
 if __name__ == "__main__":


### PR DESCRIPTION
This avoids getting an HTTP 404 when loading routes other than `/`.  Also returns 503, so that clients don't think that SkyPortal is alive before it is.