### PR TITLE
Handle migration manager checks in baselayer app service

### DIFF
--- a/services/app/app.py
+++ b/services/app/app.py
@@ -1,10 +1,12 @@
 import importlib
-
-from baselayer.app.env import load_env, parser
-from baselayer.log import make_log
+import time
 
 import tornado.log
 import tornado.ioloop
+import requests
+
+from baselayer.app.env import load_env, parser
+from baselayer.log import make_log
 
 
 parser.description = 'Launch app microservice'
@@ -12,7 +14,6 @@ parser.add_argument('-p', '--process', type=int,
                     help='Process number, when multiple server processes are used.'
                          ' This number gets added to the app port.')
 env, cfg = load_env()
-
 
 log = make_log(f'app_{env.process or 0}')
 
@@ -22,7 +23,6 @@ from baselayer.app.app_server import (
     handlers as baselayer_handlers,
     settings as baselayer_settings,
 )  # noqa: E402
-
 
 app_factory = cfg['app.factory']
 baselayer_settings['cookie_secret'] = cfg['app.secret_key']
@@ -37,6 +37,28 @@ app_factory = getattr(importlib.import_module(module), app_factory)
 
 app = app_factory(cfg, baselayer_handlers, baselayer_settings)
 app.cfg = cfg
+
+
+def migrated_db(migration_manager_port):
+    port = migration_manager_port
+    try:
+        r = requests.get(f'http://localhost:{port}')
+        status = r.json()
+    except requests.exceptions.RequestException:
+        log(f'Could not connect to migration manager on port [{port}]')
+        return None
+
+    return status["migrated"]
+
+
+# Before serving, ask migration_manager whether the DB is ready
+log('Verifying database migration status')
+port = cfg['ports.migration_manager']
+timeout = 1
+while not migrated_db(port):
+    log(f'Database not migrated, or could not verify; trying again in {timeout}s')
+    time.sleep(timeout)
+    timeout = max(timeout * 2, 30)
 
 port = cfg['ports.app_internal'] + (env.process or 0)
 app.listen(port)


### PR DESCRIPTION
Before, the app did these checks in the app_factory.  However, the
app_factory is sometimes used separately (in, e.g., documentation
build).  Now, we let the app_factory do its job: produce the app.
However, before letting the app listen on its port, we check in
with the migration manager.