### PR TITLE
run make run_testing in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ run_production: system_setup
 run_testing: FLAGS = --config=test_config.yaml  # both this and the next FLAGS definition are needed
 run_testing: system_setup
 	@echo -e "\n$(B)[baselayer] Launch app for testing$(N)"
-	@export FLAGS=$(FLAGS) && \
+	@export FLAGS="$(FLAGS) --debug" && \
 	$(ENV_SUMMARY) && \
 	$(SUPERVISORD)
 


### PR DESCRIPTION
Often in skyportal/skyportal we  see javascript errors that are inscrutable due to being minified (e.g., 

```
[33;1m[01:23:45 js] TypeError: b[e.instrument_id] is undefined
    in Sl
    in div
    in div
    in ForwardRef
    in ForwardRef
    in div
    in div
    in div
    in div
    in t
    in ForwardRef
    in ForwardRef
    in div
    in ForwardRef
    in ForwardRef
    in ForwardRef
    in ForwardRef
    in div
    in div
    in div
    in Ku
    in div
    in ForwardRef
    in ForwardRef
    in yp
    in a
    in O
    in t
    in Vt
    in t
    in div
    in de
    in Unknown
    in zy
    in Pb
    in t
    in t
    in a
    in O
    in u[0m
```

The javascript is minified because `make run_testing` (which is called by `make test`) is not run in debug mode, so webpack is run in production mode. This PR alters `make run_testing` to be run in debug mode, disabling minification in webpack. This should make it possible to interpret these errors. 