### PR TITLE
nginx: tweak buffer sizes for common upload/download scenario

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -47,6 +47,16 @@ http {
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
+
+
+      # Buffer sizes; see
+      # https://www.getpagespeed.com/server-setup/nginx/tuning-proxy_buffer_size-in-nginx
+
+      # Handle uploads up to 64k before buffering to disk
+      client_body_buffer_size 64k;
+
+      # Buffer responses up to 256k
+      proxy_buffers 32 8k;
     }
 
     location /websocket {


### PR DESCRIPTION
In our test case (SkyPortal), users often upload thumbnails on the
order of 20k to 40k; we're setting the upload buffer to 64k to
accommodate those.

For typical JSON bodies, these tend to land under 256k, so we provide
adequate buffer space for those too.

Responses should be a bit faster if they stay within buffer
limits (nothing gets buffered to disk then).