### PR TITLE
Redirect webdriven firefox console logs to geckodriver logs

### DIFF
--- a/app/test_util.py
+++ b/app/test_util.py
@@ -144,6 +144,7 @@ def driver(request):
     options = webdriver.FirefoxOptions()
     if 'BASELAYER_TEST_HEADLESS' in os.environ:
         options.headless = True
+    options.set_preference('devtools.console.stdout.content', True)
 
     profile = webdriver.FirefoxProfile()
     profile.set_preference("browser.download.manager.showWhenStarting", False)
@@ -161,7 +162,7 @@ def driver(request):
 
     driver = MyCustomWebDriver(
         firefox_profile=profile,
-        options=options
+        options=options,
     )
     driver.set_window_size(1920, 1200)
     login(driver)

--- a/app/test_util.py
+++ b/app/test_util.py
@@ -166,7 +166,6 @@ def driver(request):
         ),
     )
 
-
     driver = MyCustomWebDriver(
         firefox_profile=profile,
         options=options,


### PR DESCRIPTION
This PR alters the `MyCustomWebDriver` class which is used in unit testing. It redirects the console logs from web browser instances driven by the driver to stdout, which is then rerouted to `geckodriver.log`. This allows access to the webdriver console from unit tests 