### PR TITLE
rename owned -> readable

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -105,7 +105,7 @@ class BaseMixin(object):
         }
 
     @classmethod
-    def get_if_owned_by(cls, ident, user_or_token, options=[]):
+    def get_if_readable_by(cls, ident, user_or_token, options=[]):
         """Return an object from the database if the requesting User or Token
         has access to read the object. If the requesting User or Token does not
         have access, raise an AccessError.
@@ -126,12 +126,12 @@ class BaseMixin(object):
         """
         obj = cls.query.options(options).get(ident)
 
-        if obj is not None and not obj.is_owned_by(user_or_token):
+        if obj is not None and not obj.is_readable_by(user_or_token):
             raise AccessError('Insufficient permissions.')
 
         return obj
 
-    def is_owned_by(self, user_or_token):
+    def is_readable_by(self, user_or_token):
         """Return a boolean indicating whether a User or Token has read access
         to this object.
 
@@ -142,7 +142,7 @@ class BaseMixin(object):
 
         Returns
         -------
-        owned : bool
+        readable : bool
            Whether this object is readable to the user.
         """
         raise NotImplementedError("Ownership logic is application-specific")
@@ -429,8 +429,8 @@ class Token(Base):
         doc="The name of the token.",
     )
 
-    def is_owned_by(self, user_or_token):
-        """Return a boolean indicating whether this Token is owned by the
+    def is_readable_by(self, user_or_token):
+        """Return a boolean indicating whether this Token is readable by the
         specified User (or Token instance, if a token is passed).
 
         Parameters
@@ -440,8 +440,8 @@ class Token(Base):
 
         Returns
         -------
-        owned : bool
-           Whether this Token instance is owned by the User or Token.
+        readable : bool
+           Whether this Token instance is readable by the User or Token.
         """
         return user_or_token.id in [self.created_by_id, self.id]
 


### PR DESCRIPTION
Currently we use the adjective `owned` throughout the codebase to indicate that a user has read access to a database record. This is a bit confusing as `owned` now has a precise meaning - that a user was the one who created a record. This PR replaces `owned` -> `readable` throughout the code base to make this distinction. 