### PR TITLE
By default, do not create tables if tables already exist

### DIFF
--- a/app/model_util.py
+++ b/app/model_util.py
@@ -31,11 +31,25 @@ def drop_tables():
     meta.drop_all(bind=conn)
 
 
-def create_tables(retry=5):
-    """
-    Create tables for all models, retrying 5 times at intervals of 3
+def create_tables(retry=5, add=False):
+    """Create tables for all models, retrying 5 times at intervals of 3
     seconds if the database is not reachable.
+
+    Parameters
+    ----------
+    add : bool
+        Whether to add tables if some tables already exist.  This is
+        convenient during development, but will cause problems
+        for installations that depend on migrations to create new
+        tables.
+
     """
+    conn = models.DBSession.session_factory.kw['bind']
+    tables = models.Base.metadata.sorted_tables
+    if tables and not add:
+        print("Existing tables found; not creating additional tables")
+        return
+
     for i in range(1, retry + 1):
         try:
             conn = models.DBSession.session_factory.kw['bind']

--- a/app/model_util.py
+++ b/app/model_util.py
@@ -31,7 +31,7 @@ def drop_tables():
     meta.drop_all(bind=conn)
 
 
-def create_tables(retry=5, add=False):
+def create_tables(retry=5, add=True):
     """Create tables for all models, retrying 5 times at intervals of 3
     seconds if the database is not reachable.
 

--- a/services/app/app.py
+++ b/services/app/app.py
@@ -35,7 +35,9 @@ baselayer_settings['autoreload'] = env.debug
 module, app_factory = app_factory.rsplit('.', 1)
 app_factory = getattr(importlib.import_module(module), app_factory)
 
-app = app_factory(cfg, baselayer_handlers, baselayer_settings)
+app = app_factory(cfg, baselayer_handlers, baselayer_settings,
+                  process=env.process if env.process else 0,
+                  env=env)
 app.cfg = cfg
 
 

--- a/services/migration_manager/migration_manager.py
+++ b/services/migration_manager/migration_manager.py
@@ -137,8 +137,9 @@ if __name__ == "__main__":
     except Exception as e:
         log(f'Uncaught exception: {e}')
 
-    app = make_app()
+    migration_manager = make_app()
+
     port = cfg['ports.migration_manager']
-    app.listen(port)
+    migration_manager.listen(port)
     log(f'Listening on port {port}')
     tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
This is needed to support migrations.