### PR TITLE
Lower timeout from 10s to 5s

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -16,7 +16,7 @@ http {
   upstream frontends {
     least_conn;
     {% for p in range(server.processes) -%}
-      server 127.0.0.1:{{ ports.app_internal + p }};
+      server 127.0.0.1:{{ ports.app_internal + p }} fail_timeout=5s;
     {% endfor %}
     server 127.0.0.1:{{ ports.status }} backup max_fails=0;
   }


### PR DESCRIPTION
We don't expect these servers ever to be down.  If they are, pinging
them once every 5s is not too much of a burden.  This also allows for
more rapid recovery once they become available.