### PR TITLE
allow users to control which tests they run using make directives

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,20 @@ SUPERVISORD_CFG=baselayer/conf/supervisor/supervisor.conf
 SUPERVISORD=$(PYTHON) -m supervisor.supervisord -s -c $(SUPERVISORD_CFG)
 SUPERVISORCTL=$(PYTHON) -m supervisor.supervisorctl -c $(SUPERVISORD_CFG)
 
+# Set the test spec to the empty string by default,
+# which causes the make test_headless and make test
+# commands to run all the tests. To run only specific
+# tests, set this variable in the invocation of make,
+# e.g.,
+#
+#   make test_headless TEST_SPEC="app/tests/api"
+#
+# or, for multiple folders,
+#
+#   make test_headless TEST_SPEC="app/tests/api,app/tests/frontend"
+
+TEST_SPEC ?= ""
+
 LOG=@$(PYTHON) -c "from baselayer.log import make_log; spl = make_log('baselayer'); spl('$1')"
 
 # Bold
@@ -133,11 +147,11 @@ status:
 
 test_headless: ## Run tests headlessly
 test_headless: system_setup
-	@PYTHONPATH='.' baselayer/tools/test_frontend.py --headless --xml
+	@PYTHONPATH='.' baselayer/tools/test_frontend.py --headless --xml $(TEST_SPEC)
 
 test: ## Run tests.
 test: system_setup
-	@PYTHONPATH='.' ./baselayer/tools/test_frontend.py --xml
+	@PYTHONPATH='.' ./baselayer/tools/test_frontend.py --xml $(TEST_SPEC)
 
 test_report: ## Print report on failed tests
 test_report:

--- a/tools/test_frontend.py
+++ b/tools/test_frontend.py
@@ -79,8 +79,8 @@ if __name__ == '__main__':
         'test_spec',
         nargs='?',
         default=None,
-        help='''Test spec. Example:
-    test_frontend.py skyportal/tests/api
+        help='''Test spec passed to py.test. Separate command line tokens with commas. Example:
+    test_frontend.py skyportal/tests/api,skyportal/tests/frontend
 ''',
     )
     parser.add_argument('--xml', action='store_true', help='Save JUnit xml output to `test-results/junit.xml`')
@@ -97,8 +97,8 @@ if __name__ == '__main__':
     app_name = cfg['app.factory'].split('.')[0]
     init_db(**cfg['database'])
 
-    if args.test_spec is not None:
-        test_spec = args.test_spec
+    if args.test_spec:
+        test_spec = ' '.join(args.test_spec.split(','))
     else:
         test_spec = basedir / app_name / 'tests'
 


### PR DESCRIPTION
Currently when users call 

```
make test
```

or 

```
make test_headless
```

there is no way of specifying which tests to run; all tests are run. Recently it was requested that the new skyportal model tests be broken out to run in a separate CI job than the api and frontend tests to keep the runtime of CI down. In order to do this we need a way of specifying which tests to run in a `make` directive.  This PR facilitates that by allowing users to specify a `TEST_SPEC` to the `make test` and `make test_headless` directives. E.g., to run only the api tests via `make test`, one could do

```
make test TEST_SPEC='skyportal/tests/api'
```

and only the API tests would run. If `TEST_SPEC` is not specified then the current behavior is recovered, i.e., all tests run. 