### PR TITLE
Monitor template files

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -29,7 +29,6 @@ def ensure_yaml_routes_matches_defaults(config_path, defaults_config_path):
         print("  config.yaml app.routes differs from config.yaml.defaults:")
         pprint(difference)
         raise KeyError("Fix config.yaml before proceeding")
-    print("config.yaml app.routes matches that of config.yaml.defaults")
 
 
 def recursive_update(d, u):

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ phonenumbers>=8.12.15
 python-slugify>=4.0.1
 numpy>=0.17
 deepdiff>=5.0.2
+watchdog>=2

--- a/services/template_watch/supervisor.conf
+++ b/services/template_watch/supervisor.conf
@@ -1,0 +1,7 @@
+[program:template_watch]
+command=/usr/bin/env python baselayer/services/template_watch/template_watch.py %(ENV_FLAGS)s
+environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
+startretries=0
+startsecs=1
+stdout_logfile=log/template_watch.log
+redirect_stderr=true

--- a/services/template_watch/template_watch.py
+++ b/services/template_watch/template_watch.py
@@ -1,0 +1,46 @@
+import os
+from os.path import join as pjoin
+import time
+import sys
+
+from watchdog.observers import Observer
+from watchdog.events import PatternMatchingEventHandler
+
+from baselayer.log import make_log
+from baselayer.tools.fill_conf_values import fill_config_file_values
+from baselayer.app.env import load_env
+
+log = make_log('template_watch')
+env, cfg = load_env()
+
+if not env.debug:
+    log('Watcher only used in debug mode; exiting')
+    sys.exit(0)
+
+# Baselayer parent project path
+watchpath = os.path.abspath(pjoin(os.path.dirname(__file__), '../../..'))
+
+
+class EventHandler(PatternMatchingEventHandler):
+    def __init__(self):
+        PatternMatchingEventHandler.__init__(self, patterns=['*.template'])
+
+    def on_modified(self, event):
+        fill_config_file_values([event.src_path])
+
+
+if __name__ == "__main__":
+    event_handler = EventHandler()
+
+    observer = Observer()
+    observer.schedule(event_handler, watchpath, recursive=True)
+    observer.start()
+
+    log(f'Watching for template file changes in {watchpath}')
+
+    try:
+        while True:
+            time.sleep(3)
+    finally:
+        observer.stop()
+        observer.join()

--- a/tools/fill_conf_values.py
+++ b/tools/fill_conf_values.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
 import os
-from status import status
 
+from baselayer.tools.status import status
 from baselayer.app.env import load_env
 from baselayer.log import make_log
 


### PR DESCRIPTION
I sometimes forget that `.template` files aren't compiled automatically, prompting investigation into why changes aren't propagated.

This PR introduces a file monitor, that compiles templates when they are modified, which in turn triggers webpack (in the case of JavaScript).
