### PR TITLE
junitxml_report: derive filename from classname

### DIFF
--- a/tools/junitxml_report.py
+++ b/tools/junitxml_report.py
@@ -53,7 +53,7 @@ for test in tests:
         message = test['failure']['@message']
         text = test['failure']['#text']
 
-        filename = test['@file']
+        filename = test["@classname"].replace('.', '/') + '.py'
         test_name = test['@name']
 
         first_error = []


### PR DESCRIPTION
This should address the failures we've been seeing in log parsing on CI.