### PR TITLE
Shut down all webpack processes

### DIFF
--- a/services/webpack/supervisor.conf
+++ b/services/webpack/supervisor.conf
@@ -7,3 +7,4 @@ startretries=0
 startsecs=1
 stdout_logfile=log/webpack.log
 redirect_stderr=true
+stopasgroup=true


### PR DESCRIPTION
Otherwise, webpack leaves a node server running for about 40 seconds