### PR TITLE
Add service for mocking external APIs in testing

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -67,6 +67,7 @@ ports:
     websocket_path_out: 'ipc://run/message_flow_out'
     status: 64500
     migration_manager: 64501
+    test_server: 64502
 
 external_logging:
     papertrail:
@@ -78,6 +79,19 @@ external_logging:
        port:
        # which log files, if any do you not want to send over to the 3rd party?
        excluded_log_files: [""]
+
+test_server:
+    # The Python module to import for the test server microservice
+    # The module here should have a make_app() function which returns a 
+    # Tornado Application instance.
+    #
+    # To make use of the test_server service, you can load in a test_config.yaml
+    # when running `make test` or `make run_testing` which overrides URLs for 
+    # external APIs to point to http://localhost:{configs[ports.test_server]}.
+    # The test_server microservice can then return mock responses to the test
+    # baselayer app. 
+    module: example_test_server
+    path: services/test_server/example_test_server.py
 
 # You can schedule jobs to run at a certain time interval (given in minutes).
 #

--- a/services/test_server/example_test_server.py
+++ b/services/test_server/example_test_server.py
@@ -1,33 +1,9 @@
 import tornado.web
-import tornado.wsgi
-from tornado.web import RequestHandler
-
-from spyne.application import Application
-from spyne.decorator import srpc
-from spyne.service import ServiceBase
-from spyne.server.wsgi import WsgiApplication
-from spyne.model.complex import Iterable
-from spyne.model.primitive import UnsignedInteger
-from spyne.model.primitive import String
-from spyne.protocol.soap import Soap11
 
 
-class HelloWorldService(ServiceBase):
+class TestRouteHandler(tornado.web.RequestHandler):
     """
-    This is a simple example WSDL-based SOAP service to be included
-    in the example test server. It can be used to mock responses from
-    an external SOAP server for testing.
-    """
-
-    @srpc(String, UnsignedInteger, _returns=Iterable(String))
-    def say_hello(name, times):
-        for i in range(times):
-            yield "Hello, %s" % name
-
-
-class TestRouteHandler(RequestHandler):
-    """
-    This is a simple example REST API service to be included
+    This is a very simple example REST API service to be included
     in the example test server. It can be used to mock responses from
     an external REST server for testing.
     """
@@ -43,20 +19,8 @@ def make_app():
     to run test calls to external services against. This function is imported
     and called by the test_server.py supervisord service.
     """
-    app = Application(
-        [HelloWorldService],
-        "spyne.examples.hello.http",
-        in_protocol=Soap11(validator="lxml"),
-        out_protocol=Soap11(),
-    )
-    wsgi_app = tornado.wsgi.WSGIContainer(WsgiApplication(app))
     return tornado.web.Application(
         [
             ("/api/hello", TestRouteHandler),
-            (
-                "/wsdl/hello",
-                tornado.web.FallbackHandler,
-                dict(fallback=wsgi_app),
-            ),
         ]
     )

--- a/services/test_server/example_test_server.py
+++ b/services/test_server/example_test_server.py
@@ -1,0 +1,62 @@
+import tornado.web
+import tornado.wsgi
+from tornado.web import RequestHandler
+
+from spyne.application import Application
+from spyne.decorator import srpc
+from spyne.service import ServiceBase
+from spyne.server.wsgi import WsgiApplication
+from spyne.model.complex import Iterable
+from spyne.model.primitive import UnsignedInteger
+from spyne.model.primitive import String
+from spyne.protocol.soap import Soap11
+
+
+class HelloWorldService(ServiceBase):
+    """
+    This is a simple example WSDL-based SOAP service to be included
+    in the example test server. It can be used to mock responses from
+    an external SOAP server for testing.
+    """
+
+    @srpc(String, UnsignedInteger, _returns=Iterable(String))
+    def say_hello(name, times):
+        for i in range(times):
+            yield "Hello, %s" % name
+
+
+class TestRouteHandler(RequestHandler):
+    """
+    This is a simple example REST API service to be included
+    in the example test server. It can be used to mock responses from
+    an external REST server for testing.
+    """
+
+    def get(self):
+        self.set_status(200)
+        self.write("Hello from REST server!")
+
+
+def make_app():
+    """
+    This function generates a Tornado Application to be run as a test server
+    to run test calls to external services against. This function is imported
+    and called by the test_server.py supervisord service.
+    """
+    app = Application(
+        [HelloWorldService],
+        "spyne.examples.hello.http",
+        in_protocol=Soap11(validator="lxml"),
+        out_protocol=Soap11(),
+    )
+    wsgi_app = tornado.wsgi.WSGIContainer(WsgiApplication(app))
+    return tornado.web.Application(
+        [
+            ("/api/hello", TestRouteHandler),
+            (
+                "/wsdl/hello",
+                tornado.web.FallbackHandler,
+                dict(fallback=wsgi_app),
+            ),
+        ]
+    )

--- a/services/test_server/supervisor.conf
+++ b/services/test_server/supervisor.conf
@@ -1,0 +1,5 @@
+[program:testserver]
+command=/usr/bin/env python baselayer/services/test_server/test_server.py %(ENV_FLAGS)s
+environment=PYTHONPATH=".",PYTHONUNBUFFERED="1"
+stdout_logfile=log/test_server.log
+redirect_stderr=true

--- a/services/test_server/test_server.py
+++ b/services/test_server/test_server.py
@@ -1,0 +1,36 @@
+import importlib.util
+from pathlib import Path
+
+import tornado.ioloop
+import tornado.httpserver
+
+from baselayer.app.env import load_env
+from baselayer.log import make_log
+
+
+if __name__ == "__main__":
+    env, cfg = load_env()
+    log = make_log("testserver")
+
+    if "test_server" in cfg:
+        # Resolve server module path
+        path = Path(cfg["test_server.path"])
+        if not path.is_absolute():
+            path = path.resolve()
+        log(f"Loading test server app from {path}")
+        # Load in a configurable test server
+        spec = importlib.util.spec_from_file_location(
+            cfg["test_server.module"], path
+        )
+        test_server = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(test_server)
+        # The test server module must provide a Tornado Application
+        # returned by a function called "make_app".
+
+        app = test_server.make_app()
+        server = tornado.httpserver.HTTPServer(app)
+        port = cfg["ports.test_server"]
+        server.listen(port)
+
+        log(f"Listening for test HTTP requests on port {port}")
+        tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
This PR adds a `test_service` service to Baselayer which can be used to mock external API requests during testing. The idea is to tweak configurations for test instances of a Baselayer application (through a `test_config.yaml` like in SkyPortal, for example) such that external API calls made by the application's handlers are directed to `http://localhost:{configs[ports.test_server]}` instead of the real API host; the `test_service` will return mock responses to the Baselayer application. These mock responses are set up and customized by passing to the microservice via configurations the path to a Python module which exposes a `make_app()` function returning a  `tornado.web.Application` instance. An example such module is provided and configured in the default configs.

This is a precursor to addressing skyportal/skyportal#1792. A follow-up PR will be made to SkyPortal with a more sophisticated test server module to instantiate the microservice with in order to mock external calls within the SkyPortal test suite.