### PR TITLE
clear the sqlalchemy session at the beginning of each api handler call

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -158,6 +158,10 @@ class BaseHandler(PSABaseHandler):
         self.cfg = self.application.cfg
         self.flow = Flow()
 
+        # clear any objects that may remain in the session from
+        # initialization of the app
+        DBSession.remove()
+
         # Remove slash prefixes from arguments
         if self.path_args:
             self.path_args = [


### PR DESCRIPTION
When we start the app, a bunch of mapped objects are loaded into the database session (ACLs, admin users, etc.), which then stay in the session during the first API handler call on each web worker. When `verify_permissions` is first called, it checks permissions on everything in the session, which includes the stale references from app startup. Sometimes, the first API call can throw a permission error if we try to check the permissions of a stale object that is irrelevant to the current transaction but has just stayed in the app from app startup. This PR modifies the base handler to clear the database session at the beginning of each api handler call, ensuring that objects in the database session are only relevant to the API call (and thus any permissions errors that are thrown are actually related to the current transaction). 