### PR TITLE
Security Improvements

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -152,7 +152,10 @@ class BaseHandler(PSABaseHandler):
                         f'{mode} {type(row).__name__} {row.id}".'
                     )
 
-    def finalize_transaction(self):
+    def verify_and_commit(self):
+        """Verify permissions on the current database session and commit if
+        successful, otherwise raise an AccessError.
+        """
         self.verify_permissions()
         DBSession().commit()
 

--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -6,6 +6,7 @@ from tornado.web import RequestHandler
 from tornado.log import app_log
 from json.decoder import JSONDecodeError
 from ..models import session_context_id
+from collections import defaultdict
 
 # The Python Social Auth base handler gives us:
 #   user_id, get_current_user, login_user
@@ -18,7 +19,7 @@ import social_tornado.handlers as psa_handlers
 # Initialize PSA tornado models
 from .. import psa  # noqa
 
-from ..models import DBSession, User, verify
+from ..models import DBSession, User, handle_inaccessible
 from ..json_util import to_json
 from ..flow import Flow
 from ..env import load_env
@@ -85,6 +86,48 @@ class PSABaseHandler(RequestHandler):
             )
 
 
+def bulk_verify(mode, collection, accessor):
+    """Vectorized permission check for a heterogeneous set of records. If an
+    access leak is detected, it will be handled according to the `security`
+    section of the application's configuration.
+
+    Parameters
+    ----------
+    mode: str
+        The access mode to check. Can be create, read, update, or delete.
+    collection: collection of `baselayer.app.models.Base`.
+        The records to check. These records will be grouped by type, and
+        a single database query will be issued to check access for each
+        record type.
+    accessor: baselayer.app.models.User or baselayer.app.models.Token
+        The user or token to check.
+    """
+
+    grouped_collection = defaultdict(list)
+    for row in collection:
+        grouped_collection[type(row)].append(row)
+
+    # check all rows of the same type with a single database query
+    for record_cls, collection in grouped_collection.items():
+        collection_ids = set(record.id for record in collection)
+
+        # vectorized query for ids of rows in the session that
+        # are accessible
+        accessible_row_ids = record_cls.query_records_accessible_by(
+            accessor, mode=mode, columns=[record_cls.id]
+        ).filter(record_cls.id.in_(collection_ids))
+
+        # compare the accessible ids with the ids that are in the session
+        accessible_row_ids = set(id for id, in accessible_row_ids)
+        inaccessible_row_ids = collection_ids - accessible_row_ids
+
+        # if any of the rows in the session are inaccessible, handle
+        if len(inaccessible_row_ids) > 0:
+
+            inaccessible_rows = record_cls.query.get(inaccessible_row_ids)
+            handle_inaccessible(mode, inaccessible_rows, accessor)
+
+
 # Monkey-patch in each method of social_tornado.handlers.BaseHandler
 for (name, fn) in inspect.getmembers(
     PSABaseHandler, predicate=inspect.isfunction
@@ -127,16 +170,13 @@ class BaseHandler(PSABaseHandler):
             ['read', 'update', 'delete'],
             [read_rows, updated_rows, deleted_rows],
         ):
-            for row in collection:
-                verify(mode, row, self.current_user)
+            bulk_verify(mode, collection, self.current_user)
 
         # update transaction state in DB, but don't commit yet. this updates
         # or adds rows in the database and uses their new state in joins,
         # for permissions checking purposes.
         DBSession().flush()
-
-        for row in new_rows:
-            verify('create', row, self.current_user)
+        bulk_verify('create', new_rows, self.current_user)
 
     def verify_and_commit(self):
         """Verify permissions on the current database session and commit if

--- a/app/models.py
+++ b/app/models.py
@@ -1,9 +1,12 @@
 import uuid
 import contextvars
 from hashlib import md5
+import warnings
 
 import numpy as np
 import sqlalchemy as sa
+import traceback
+import requests
 from slugify import slugify
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSONB
@@ -14,9 +17,42 @@ from sqlalchemy_utils import EmailType, PhoneNumberType
 
 from .custom_exceptions import AccessError
 from .json_util import to_json
+from .env import load_env
 
 session_context_id = contextvars.ContextVar('request_id', default=None)
 DBSession = scoped_session(sessionmaker(), scopefunc=session_context_id.get)
+
+env, cfg = load_env()
+strict = cfg['security']['strict']
+use_webhook = cfg['security']['slack']['enabled']
+webhook_url = cfg['security']['slack']['url']
+
+
+def verify(mode, row, accessor):
+    """Verifies that User or Token `accessor` can access `Base` row
+    in mode `mode` (can be create, read, update, or delete)."""
+
+    if not row.is_accessible_by(accessor, mode=mode):
+        tb = ''.join(traceback.extract_stack().format()[-3:-1])
+        tb = f'```{tb}```'
+        err_msg = (
+            f'Insufficient permissions for operation '
+            f'"{type(accessor).__name__} {accessor.id} '
+            f'{mode} {type(row).__name__} {row.id}". Original traceback: {tb}'
+        )
+        if use_webhook:
+            try:
+                requests.post(webhook_url, json={'text': err_msg})
+            except requests.HTTPError as e:
+                post_fail_warn_msg = f'Encountered HTTPError "{e.args[0]}" ' \
+                                     f'attempting to post AccessError "{err_msg}"' \
+                                     f'to {webhook_url}.'
+                warnings.warn(post_fail_warn_msg)
+        else:
+            warnings.warn(err_msg)
+        if strict:
+            raise AccessError(err_msg)
+
 
 # https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#psycopg2-fast-execution-helpers
 # executemany_values_page_size arguments control how many parameter sets

--- a/app/models.py
+++ b/app/models.py
@@ -59,13 +59,6 @@ def handle_inaccessible(mode, row_or_rows, accessor):
         raise AccessError(err_msg)
 
 
-def verify(mode, row, accessor):
-    """Verifies that User or Token `accessor` can access `Base` row
-    in mode `mode` (can be create, read, update, or delete)."""
-    if not row.is_accessible_by(accessor, mode=mode):
-        handle_inaccessible(mode, row, accessor)
-
-
 # https://docs.sqlalchemy.org/en/13/dialects/postgresql.html#psycopg2-fast-execution-helpers
 # executemany_values_page_size arguments control how many parameter sets
 # should be represented in each execution of an INSERT

--- a/app/models.py
+++ b/app/models.py
@@ -33,7 +33,7 @@ def verify(mode, row, accessor):
     in mode `mode` (can be create, read, update, or delete)."""
 
     if not row.is_accessible_by(accessor, mode=mode):
-        tb = ''.join(traceback.extract_stack().format()[-3:-1])
+        tb = ''.join(traceback.extract_stack().format()[:-1])
         tb = f'```{tb}```'
         err_msg = (
             f'Insufficient permissions for operation '

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -79,6 +79,13 @@ external_logging:
        # which log files, if any do you not want to send over to the 3rd party?
        excluded_log_files: [""]
 
+security:
+	strict: true
+	slack:
+		enabled: false
+		url: null
+
+
 # You can schedule jobs to run at a certain time interval (given in minutes).
 #
 # If baselayer is not running at the time the job is supposed to run,

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -80,10 +80,10 @@ external_logging:
        excluded_log_files: [""]
 
 security:
-	strict: true
-	slack:
-		enabled: false
-		url: null
+  strict: true
+  slack:
+    enabled: false
+    url: null
 
 
 # You can schedule jobs to run at a certain time interval (given in minutes).


### PR DESCRIPTION
This PR contains three improvements around security. 

1. I added a Security section to `config.defaults.yaml`. This allows users to enable or disable "strict" mode. When strict is on, any illegal access detected by `self.verify_permissions()` is raised as an exception. Otherwise, it is simply issued as a warning. I also added an option to send security reports to a webhook channel (i.e., slack) in strict or non-strict mode. 
2. I augmented the error messages sent to the slack channel with a full traceback to show what handler a particular access violation occurred in. 
3. I vectorized the security checks within `self.verify_permissions()`. Previously, each record would issue a separate database query for permissions checks. Although each check was fast on its own (~0.5ms), for  pages with lots of the same type of record in the session, O(10^4) checks could be issued, adding a few extra seconds to the handler response time. This PR issues one (fast) database query per (access mode, record type) pair, potentially reducing the access checking overhead for pages which deal with many records by several orders of magnitude. 