### PR TITLE
fix bulk permissions checker

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -128,8 +128,7 @@ def bulk_verify(mode, collection, accessor):
 
         # if any of the rows in the session are inaccessible, handle
         if len(inaccessible_row_ids) > 0:
-            inaccessible_rows = record_cls.query.get(inaccessible_row_ids)
-            handle_inaccessible(mode, inaccessible_rows, accessor)
+            handle_inaccessible(mode, inaccessible_row_ids, record_cls, accessor)
 
 
 # Monkey-patch in each method of social_tornado.handlers.BaseHandler

--- a/app/models.py
+++ b/app/models.py
@@ -28,20 +28,14 @@ use_webhook = cfg['security.slack.enabled']
 webhook_url = cfg['security.slack.url']
 
 
-def handle_inaccessible(mode, row_or_rows, accessor):
+def handle_inaccessible(mode, row_ids, row_type, accessor):
     tb = ''.join(traceback.extract_stack().format())
     tb = f'```{tb}```'
-
-    # format the error message
-    original_shape = np.asarray(row_or_rows).shape
-    standardized = np.atleast_1d(row_or_rows).tolist()
-    row_typename = type(standardized[0]).__name__
-    row_id_or_ids = np.asarray([r.id for r in standardized]).reshape(original_shape).tolist()
 
     err_msg = (
         f'Insufficient permissions for operation '
         f'"{type(accessor).__name__} {accessor.id} '
-        f'{mode} {row_typename} {row_id_or_ids}".'
+        f'{mode} {row_type.__name__} {row_ids}".'
     )
     err_msg_w_traceback = err_msg + f'Original traceback: {tb}'
 


### PR DESCRIPTION
This pr eliminates the use of `Base.query.get(pk_set)` in the bulk permissions checker, which was causing errors to raise for pk_sets with a cardinality greater than 1. 