### PR TITLE
Simplify access controls for system admins

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -68,8 +68,13 @@ utcnow = func.timezone("UTC", func.current_timestamp())
 # The db has to be initialized later; this is done by the app itself
 # See `app_server.py`
 def init_db(
-        user, database, password=None, host=None, port=None, autoflush=True,
-        engine_args={}
+    user,
+    database,
+    password=None,
+    host=None,
+    port=None,
+    autoflush=True,
+    engine_args={},
 ):
     """
     Parameters
@@ -93,14 +98,16 @@ def init_db(
     url = url.format(user, password or "", host or "", port or "", database)
 
     default_engine_args = {
-            'pool_size': 5, 'max_overflow': 10, 'pool_recycle': 3600
-        }
+        "pool_size": 5,
+        "max_overflow": 10,
+        "pool_recycle": 3600,
+    }
     conn = sa.create_engine(
         url,
         client_encoding="utf8",
         executemany_mode="values",
         executemany_values_page_size=EXECUTEMANY_PAGESIZE,
-        **{**default_engine_args, **engine_args}
+        **{**default_engine_args, **engine_args},
     )
 
     DBSession.configure(bind=conn, autoflush=autoflush)
@@ -474,6 +481,12 @@ class AccessibleIfRelatedRowsAreAccessible(UserAccessControl):
             Query for the accessible rows.
         """
 
+        # system admins automatically get full access
+        if user_or_token.is_admin:
+            return public.query_accessible_rows(
+                cls, user_or_token, columns=columns
+            )
+
         # only return specified columns if requested
         if columns is None:
             base = DBSession().query(cls)
@@ -595,6 +608,11 @@ class ComposedAccessControl(UserAccessControl):
         query: sqlalchemy.Query
             Query for the accessible rows.
         """
+        # system admins automatically get full access
+        if user_or_token.is_admin:
+            return public.query_accessible_rows(
+                cls, user_or_token, columns=columns
+            )
 
         # retrieve specified columns if requested
         if columns is not None:


### PR DESCRIPTION
This PR simplifies the permissions querying for system admins for the baselayer-provided permission rule classes. Specifically, all rows are just returned if the user is a system admin without doing any of the normal checks when using the `AccessibleIfRelatedRowsAreAccessible` and `ComposedAccessControl` classes. This reflects the same approach already used in `AccessibleIfUserMatches`. 

For example, if you have a rule that is the AND of two rules, the `ComposedAccessControl` as is will join the entire table in question to itself since both pieces of the permission rule will return all rows for a system admin. Now, we'll just return the table once. 