### PR TITLE
Pass originating IP through to app

### DIFF
--- a/services/app/app.py
+++ b/services/app/app.py
@@ -63,7 +63,7 @@ while not migrated_db(port):
     timeout = max(timeout * 2, 30)
 
 port = cfg['ports.app_internal'] + (env.process or 0)
-app.listen(port)
+app.listen(port, xheaders=True)
 
 log(f'Listening on port {port}')
 tornado.ioloop.IOLoop.current().start()


### PR DESCRIPTION
We may still need to provide trusted IPs for our load balancers in
order to get the user IP, as described in the last paragraph below.

From the Tornado docs (https://www.tornadoweb.org/en/stable/httpserver.html):

  > If xheaders is True, we support the X-Real-Ip/X-Forwarded-For and
  X-Scheme/X-Forwarded-Proto headers, which override the remote IP and
  URI scheme/protocol for all requests. These headers are useful when
  running Tornado behind a reverse proxy or load balancer. The
  protocol argument can also be set to https if Tornado is run behind
  an SSL-decoding proxy that does not set one of the supported
  xheaders.
 >
  > By default, when parsing the X-Forwarded-For header, Tornado will
  select the last (i.e., the closest) address on the list of hosts as
  the remote host IP address. To select the next server in the chain,
  a list of trusted downstream hosts may be passed as the
  trusted_downstream argument. These hosts will be skipped when
  parsing the X-Forwarded-For header.