### PR TITLE
Explicitly set BaseMixin id to autoincrement

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -951,7 +951,7 @@ class BaseMixin:
 
     query = DBSession.query_property()
     id = sa.Column(
-        sa.Integer, primary_key=True, doc="Unique object identifier."
+        sa.Integer, primary_key=True, autoincrement=True, doc="Unique object identifier."
     )
     created_at = sa.Column(
         sa.DateTime,


### PR DESCRIPTION
This is the implicit default behavior when `id` is a single-column primary key, but `autoincrement=True` must be set explicitly when the `id` column is used as a part of a multiple-column primary key. This allows subclassed models to specify additional columns as part of the primary key. 

https://docs.sqlalchemy.org/en/14/core/metadata.html?highlight=autoincrement#sqlalchemy.schema.Column.params.autoincrement