### PR TITLE
Add expiration_date to Users

### DIFF
--- a/app/access.py
+++ b/app/access.py
@@ -26,13 +26,13 @@ def auth_or_token(method):
             if token is not None:
                 self.current_user = token
                 if not token.created_by.is_active():
-                    raise tornado.web.HTTPError(403, "User account expired")
+                    raise tornado.web.HTTPError(401, "User account expired")
             else:
-                raise tornado.web.HTTPError(403)
+                raise tornado.web.HTTPError(401)
             return method(self, *args, **kwargs)
         else:
             if not self.current_user.is_active():
-                raise tornado.web.HTTPError(403, "User account expired")
+                raise tornado.web.HTTPError(401, "User account expired")
             return tornado.web.authenticated(method)(self, *args, **kwargs)
 
     return wrapper
@@ -51,7 +51,7 @@ def permissions(acl_list):
                 set(acl_list).issubset(self.current_user.permissions)
                 or "System admin" in self.current_user.permissions
             ):
-                raise tornado.web.HTTPError(403)
+                raise tornado.web.HTTPError(401)
             return method(self, *args, **kwargs)
 
         return wrapper

--- a/app/access.py
+++ b/app/access.py
@@ -26,13 +26,13 @@ def auth_or_token(method):
             if token is not None:
                 self.current_user = token
                 if not token.created_by.is_active():
-                    raise tornado.web.HTTPError(401, "User account expired")
+                    raise tornado.web.HTTPError(403, "User account expired")
             else:
                 raise tornado.web.HTTPError(401)
             return method(self, *args, **kwargs)
         else:
             if not self.current_user.is_active():
-                raise tornado.web.HTTPError(401, "User account expired")
+                raise tornado.web.HTTPError(403, "User account expired")
             return tornado.web.authenticated(method)(self, *args, **kwargs)
 
     return wrapper

--- a/app/access.py
+++ b/app/access.py
@@ -19,16 +19,20 @@ def auth_or_token(method):
 
     @functools.wraps(method)
     def wrapper(self, *args, **kwargs):
-        token_header = self.request.headers.get('Authorization', None)
-        if token_header and token_header.startswith('token '):
-            token_id = token_header.replace('token', '').strip()
+        token_header = self.request.headers.get("Authorization", None)
+        if token_header and token_header.startswith("token "):
+            token_id = token_header.replace("token", "").strip()
             token = Token.query.get(token_id)
             if token is not None:
                 self.current_user = token
+                if not token.created_by.is_active():
+                    raise tornado.web.HTTPError(403, "User account expired")
             else:
                 raise tornado.web.HTTPError(403)
             return method(self, *args, **kwargs)
         else:
+            if not self.current_user.is_active():
+                raise tornado.web.HTTPError(403, "User account expired")
             return tornado.web.authenticated(method)(self, *args, **kwargs)
 
     return wrapper

--- a/app/models.py
+++ b/app/models.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import uuid
 import contextvars
 from hashlib import md5
@@ -68,8 +69,13 @@ utcnow = func.timezone("UTC", func.current_timestamp())
 # The db has to be initialized later; this is done by the app itself
 # See `app_server.py`
 def init_db(
-        user, database, password=None, host=None, port=None, autoflush=True,
-        engine_args={}
+    user,
+    database,
+    password=None,
+    host=None,
+    port=None,
+    autoflush=True,
+    engine_args={},
 ):
     """
     Parameters
@@ -93,14 +99,16 @@ def init_db(
     url = url.format(user, password or "", host or "", port or "", database)
 
     default_engine_args = {
-            'pool_size': 5, 'max_overflow': 10, 'pool_recycle': 3600
-        }
+        "pool_size": 5,
+        "max_overflow": 10,
+        "pool_recycle": 3600,
+    }
     conn = sa.create_engine(
         url,
         client_encoding="utf8",
         executemany_mode="values",
         executemany_values_page_size=EXECUTEMANY_PAGESIZE,
-        **{**default_engine_args, **engine_args}
+        **{**default_engine_args, **engine_args},
     )
 
     DBSession.configure(bind=conn, autoflush=autoflush)
@@ -951,7 +959,10 @@ class BaseMixin:
 
     query = DBSession.query_property()
     id = sa.Column(
-        sa.Integer, primary_key=True, autoincrement=True, doc="Unique object identifier."
+        sa.Integer,
+        primary_key=True,
+        autoincrement=True,
+        doc="Unique object identifier.",
     )
     created_at = sa.Column(
         sa.DateTime,
@@ -1254,6 +1265,11 @@ class User(Base):
         passive_deletes=True,
         doc="ACLs granted to user, separate from role-level ACLs",
     )
+    expiration_date = sa.Column(
+        sa.DateTime,
+        nullable=True,
+        doc="The date until which the user's account is valid. Users are set to view-only upon expiration.",
+    )
 
     @property
     def gravatar_url(self):
@@ -1295,7 +1311,11 @@ class User(Base):
 
     def is_active(self):
         """Boolean flag indicating whether the User is currently active."""
-        return True
+        return (
+            True
+            if self.expiration_date is None
+            else self.expiration_date > datetime.now()
+        )
 
     is_admin = property(is_admin)
 


### PR DESCRIPTION
Also changed the `is_active` function for Users, which currently is just returning `True` no matter what, so that it serves as a check for expired users. We don't seem to be using this function anywhere, but doesn't hurt to have it be more of a real function in case we use it later. This will be accompanied by a PR on SkyPortal to actually use the new column for user expiration functionality (setting expired users to view only automatically). Part of addressing fritz-marshal/fritz#180

Plus black formatting.