### PR TITLE
Add API rate limiting

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -85,6 +85,11 @@ security:
     enabled: false
     url: null
 
+misc:
+  # Minimum interval during which 100 requests will be allowed per API token,
+  # per app instance (tokens with "System admin" ACL are not limited)
+  rate_limit_100_requests_per_n_seconds: 30
+
 
 # You can schedule jobs to run at a certain time interval (given in minutes).
 #


### PR DESCRIPTION
This PR implements a simple per-token API rate limiting check integrated with the `access` module. Note that each app instance tracks its own number of requests handled only by that instance, so the number of server processes must be taken into account when configuring rate limits.

See tests in https://github.com/skyportal/skyportal/pull/2122 
Will also add tests to baselayer template app