### PR TITLE
Include truncated http_authorization in nginx log messages

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -57,7 +57,7 @@ http {
       default 1;
   }
 
-  log_format elb_log '$proxy_add_x_forwarded_for - $remote_user [$time_local] ' '"$request" $status $body_bytes_sent "$http_referer" ' '"$http_user_agent"';
+  log_format elb_log '$proxy_add_x_forwarded_for - $remote_user $http_authorization [$time_local] ' '"$request" $status $body_bytes_sent "$http_referer" ' '"$http_user_agent"';
 
   server {
     listen {{ ports.app }};

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -57,7 +57,12 @@ http {
       default 1;
   }
 
-  log_format elb_log '$proxy_add_x_forwarded_for - $remote_user $http_authorization [$time_local] ' '"$request" $status $body_bytes_sent "$http_referer" ' '"$http_user_agent"';
+  map $http_authorization $trunc_authorization {
+    default "";
+    "~*(?P<tr>.{0,14}).*" $tr;
+  }
+
+  log_format elb_log '$proxy_add_x_forwarded_for - $remote_user [$trunc_authorization] [$time_local] ' '"$request" $status $body_bytes_sent "$http_referer" ' '"$http_user_agent"';
 
   server {
     listen {{ ports.app }};


### PR DESCRIPTION
Log messages will now be of the form `127.0.0.1 - - [token e7a82026] [20/Jul/2021:14:59:50 -0700] "GET /api/sysin HTTP/1.1" 400 110 "-" "python-requests/2.25.1"`