### PR TITLE
Up social-auth-core version to 4.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ selenium>=3.141.0
 pytest>=5.4.3
 sqlalchemy>=1.3.7,<1.4.0
 sqlalchemy-utils>=0.36.8
-social-auth-core==3.3.3
+social-auth-core==4.1.0
 social-auth-app-tornado>=1.0.0
 social-auth-storage-sqlalchemy>=1.1.0
 selenium-requests>=1.3


### PR DESCRIPTION
The currently pinned version 3.3.3 is causing trouble with OAuth: users cannot log into Fritz.
Was able to reproduce on staging F, Installed 4.1.0, issue apparently resolved.