### PR TITLE
Serve static files with correct MIME types

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -135,6 +135,7 @@ http {
       # Serve static files directly
       location /static/ {
         root .;
+        include /etc/nginx/mime.types;
         if ($query_string) {
           expires max;
         }


### PR DESCRIPTION
Otherwise, CSS will not load, e.g.