### PR TITLE
Aliasing like that does not work for sqlalchemy >= 1.4

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -621,7 +621,7 @@ class ComposedAccessControl(UserAccessControl):
                 continue
 
             # use an alias to avoid name collisions.
-            target_alias = sa.orm.aliased(cls)
+            # target_alias = sa.orm.aliased(cls)
 
             # join against the first access control using a subquery. from a
             # performance perspective this should be about as performant as
@@ -629,7 +629,7 @@ class ComposedAccessControl(UserAccessControl):
             # name collisions. The subquery is automatically de-subbed by
             # postgres and uses all available indices.
             accessible = access_control.query_accessible_rows(
-                target_alias, user_or_token, columns=[target_alias.id]
+                cls, user_or_token, columns=[cls.id]
             ).subquery()
 
             # join on the FK

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ simplejson>=3.17.2
 requests>=2.25.1
 selenium>=3.141.0
 pytest>=5.4.3
-sqlalchemy>=1.3.7,<1.4.0
+sqlalchemy>1.4.0
 sqlalchemy-utils>=0.36.8
 social-auth-core==4.1.0
 social-auth-app-tornado>=1.0.0


### PR DESCRIPTION
Allows the permissions checking to pass in sqlalchemy >= 1.4.

See: https://docs.sqlalchemy.org/en/14/changelog/migration_14.html
in particular: Built-in FROM linting will warn for any potential cartesian products in a SELECT statement
