### PR TITLE
Use psql for all database operations

### DIFF
--- a/tools/db_init.py
+++ b/tools/db_init.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-
 import subprocess
 import sys
 import argparse
@@ -42,6 +41,8 @@ if host:
 if port:
     flags += f' -p {port}'
 
+admin_flags = flags.replace(f'-U {user}', '-U postgres')
+
 test_cmd = f"{psql_cmd} {flags} -c 'SELECT 0;' "
 
 
@@ -57,13 +58,13 @@ def test_db(database):
 
 
 with status(f'Creating user {user}'):
-    run(f'{psql_cmd} {flags} -c "CREATE USER {user};"')
+    run(f'{psql_cmd} {admin_flags} -c "CREATE USER {user};"')
 
 if args.force:
     try:
         with status('Removing existing databases'):
             for current_db in all_dbs:
-                p = run(f'{psql_cmd} {flags}\
+                p = run(f'{psql_cmd} {admin_flags}\
                           -c "DROP DATABASE {current_db};"')
                 if p.returncode != 0:
                     raise RuntimeError()
@@ -80,7 +81,7 @@ with status('Creating databases'):
         if test_db(current_db):
             continue
 
-        p = run(f'{psql_cmd} {flags}\
+        p = run(f'{psql_cmd} {admin_flags}\
                   -c "CREATE DATABASE {current_db};"')
         if p.returncode == 0:
             run(f'{psql_cmd} {flags}\

--- a/tools/db_init.py
+++ b/tools/db_init.py
@@ -34,7 +34,7 @@ flags = f'-U {user}'
 
 if password:
     psql_cmd = f'PGPASSWORD="{password}" {psql_cmd}'
-flags += f' --no-password'
+flags += ' --no-password'
 
 if host:
     flags += f' -h {host}'
@@ -72,13 +72,14 @@ else:
 run(f'{sudo} echo -n')
 
 with status(f'Creating user {user}'):
-    run(f'{sudo} createuser {user}')
+    run(f'{sudo} {psql_cmd} {flags} -c "CREATE USER {user};"')
 
 if args.force:
     try:
         with status('Removing existing databases'):
             for current_db in all_dbs:
-                p = run(f'{sudo} dropdb {current_db}')
+                p = run(f'{sudo} {psql_cmd} {flags}\
+                          -c "DROP DATABASE {current_db};"')
                 if p.returncode != 0:
                     raise RuntimeError()
     except RuntimeError:
@@ -86,7 +87,7 @@ if args.force:
               f'{textwrap.indent(p.stderr.decode("utf-8").strip(), prefix="  ")}\n')
         sys.exit(1)
 
-with status(f'Creating databases'):
+with status('Creating databases'):
     for current_db in all_dbs:
         # We allow this to fail, because oftentimes because of complicated db setups
         # users want to create their own databases
@@ -94,11 +95,12 @@ with status(f'Creating databases'):
         if test_db(current_db):
             continue
 
-        p = run(f'{sudo} createdb -w {current_db}')
+        p = run(f'{sudo} {psql_cmd} {flags}\
+                  -c "CREATE DATABASE {current_db};"')
         if p.returncode == 0:
             run(f'{psql_cmd} {flags}\
-              -c "GRANT ALL PRIVILEGES ON DATABASE {current_db} TO {user};"\
-              {current_db}')
+                 -c "GRANT ALL PRIVILEGES ON DATABASE {current_db} TO {user};"\
+                 {current_db}')
         else:
             print()
             print(f'Warning: could not create db {current_db}')

--- a/tools/db_init.py
+++ b/tools/db_init.py
@@ -56,29 +56,14 @@ def test_db(database):
     return (p.returncode == 0)
 
 
-plat = run('uname').stdout
-sudo = ''
-if b'Darwin' in plat:
-    print('* Configuring MacOS postgres [no sudo]')
-else:
-    if shutil.which('sudo'):
-        print('* Configuring Linux postgres [sudo will ask password]')
-        sudo = 'sudo -u postgres'
-    else:
-        print('* Configuring Linux postgres [no sudo]')
-
-# Ask for sudo password here so that it is printed on its own line
-# (better than inside a `with status` section)
-run(f'{sudo} echo -n')
-
 with status(f'Creating user {user}'):
-    run(f'{sudo} {psql_cmd} {flags} -c "CREATE USER {user};"')
+    run(f'{psql_cmd} {flags} -c "CREATE USER {user};"')
 
 if args.force:
     try:
         with status('Removing existing databases'):
             for current_db in all_dbs:
-                p = run(f'{sudo} {psql_cmd} {flags}\
+                p = run(f'{psql_cmd} {flags}\
                           -c "DROP DATABASE {current_db};"')
                 if p.returncode != 0:
                     raise RuntimeError()
@@ -95,7 +80,7 @@ with status('Creating databases'):
         if test_db(current_db):
             continue
 
-        p = run(f'{sudo} {psql_cmd} {flags}\
+        p = run(f'{psql_cmd} {flags}\
                   -c "CREATE DATABASE {current_db};"')
         if p.returncode == 0:
             run(f'{psql_cmd} {flags}\


### PR DESCRIPTION
Previously, we used dropdb, createdb, and createuser, but these
commands operate on the local database, and thus is not suitable for
working in a Docker container network.