### PR TITLE
Refresh tables using migration manager

### DIFF
--- a/services/migration_manager/migration_manager.py
+++ b/services/migration_manager/migration_manager.py
@@ -5,7 +5,9 @@ import time
 import tornado.ioloop
 import tornado.web
 
+from baselayer.app.models import init_db
 from baselayer.app.env import load_env
+from baselayer.app.model_util import create_tables
 from baselayer.log import make_log
 
 env, cfg = load_env()
@@ -136,6 +138,13 @@ if __name__ == "__main__":
             migrate()
     except Exception as e:
         log(f'Uncaught exception: {e}')
+
+    # If tables are found in the database, new tables will only be added
+    # in debug mode.  In production, we leave the tables alone, since
+    # migrations might be used.
+    log('Refreshing tables')
+    init_db(**cfg['database'])
+    create_tables(add=env.debug)
 
     migration_manager = make_app()
 


### PR DESCRIPTION
Requires the following patch to skyportal once merged:

```diff
-    # If tables are found in the database, new tables will only be added
-    # in debug mode.  In production, we leave the tables alone, since
-    # migrations might be used.
-    create_tables(add=env.debug)
     model_util.refresh_enums()
```

Follows up on https://github.com/skyportal/skyportal/pull/2564 and closes https://github.com/skyportal/skyportal/issues/1802