### PR TITLE
No longer enforce a route structure on the config file

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -1,35 +1,11 @@
 import os
 from pathlib import Path
 import collections.abc as collections
-from deepdiff import DeepDiff
 import yaml
-from pprint import pprint
 
 from ..log import make_log
 
 log = make_log('baselayer')
-
-
-def ensure_yaml_routes_matches_defaults(config_path, defaults_config_path):
-    # Borrowed from https://github.com/dmitryduev/kowalski/blob/master/kowalski.py
-    # check contents of config WRT config.yaml.defaults
-    with open(defaults_config_path) as defaults_yaml:
-        config_defaults = yaml.load(defaults_yaml, Loader=yaml.FullLoader)
-    with open(config_path) as config_yaml:
-        config_wildcard = yaml.load(config_yaml, Loader=yaml.FullLoader)
-    deep_diff = DeepDiff(config_wildcard, config_defaults, ignore_order=True)
-    difference = {
-        k: v
-        for k, v in deep_diff.items()
-        if k
-        in ("dictionary_item_added", "dictionary_item_removed", "iterable_item_added")
-        and "routes" in str(v)
-    }
-    if len(difference) > 0:
-        print("  config.yaml app.routes differs from config.yaml.defaults:")
-        pprint(difference)
-        raise KeyError("Fix config.yaml before proceeding")
-    print("config.yaml app.routes matches that of config.yaml.defaults")
 
 
 def recursive_update(d, u):
@@ -117,10 +93,6 @@ def load_config(config_files=[]):
         log(
             "Warning: You are running on the default configuration. To configure your system, "
             "please copy `config.yaml.defaults` to `config.yaml` and modify it as you see fit."
-        )
-    elif os.path.exists(basedir / "../config.yaml"):
-        ensure_yaml_routes_matches_defaults(
-            basedir / "../config.yaml", basedir / "../config.yaml.defaults",
         )
 
     # Always load the default configuration values first, and override

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ python-dateutil>=2.8.1
 phonenumbers>=8.12.15
 python-slugify>=4.0.1
 numpy>=0.17
-deepdiff>=5.0.2


### PR DESCRIPTION
Before, we forced config.yaml to reflect the routes in
config.yaml.default.  However, users may want to add or remove
routes by specifying a new routes key entry.