### PR TITLE
Reassign port to 5700, fix #282

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -90,7 +90,7 @@ log:
 ports:
     websocket: 64000
     fake_oauth: 63000
-    app: 5000
+    app: 5700
     app_http_proxy: 5001
     app_internal: 65000  # nginx forwards this port to ports:app
     dask: 63500


### PR DESCRIPTION
This PR changes the default baselayer port to 5700, from 5000. This avoids problems of port 5000 being occupied, as explained in #282.