### PR TITLE
Change config to avoid nginx warnings

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -7,13 +7,13 @@ worker_processes auto;
 http {
   sendfile on;
   tcp_nopush on;
+  types_hash_max_size 4096;
 
   # Enable compression of outgoing data
   gzip on;
   gzip_min_length 1000;
   gzip_proxied any;
   gzip_types text/plain
-             text/html
              text/css
              application/x-javascript
              application/xml


### PR DESCRIPTION
Specifically:

- duplicate MIME type "text/html" in ./baselayer/services/nginx/nginx.conf:20
- could not build optimal types_hash, you should increase either types_hash_max_size: 1024 or types_hash_bucket_size: 64; ignoring types_hash_bucket_size