### PR TITLE
Compress application/json responses

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -15,6 +15,7 @@ http {
   gzip_proxied any;
   gzip_types text/plain
              text/css
+             application/json
              application/x-javascript
              application/xml
              text/javascript;


### PR DESCRIPTION
This is done when the "Accept-Encoding: gzip" header is present, which
seems to be the case for `fetch` API requests.