### PR TITLE
Add '--legacy-peer-deps' flag for npm install

### DIFF
--- a/tools/check_js_deps.sh
+++ b/tools/check_js_deps.sh
@@ -6,7 +6,7 @@ BASEDIR=$(dirname "$0")
 CHECKER="$BASEDIR/../../node_modules/.bin/check-dependencies"
 
 if [[ ! -x ${CHECKER} ]]; then
-    npm install check-dependencies
+    npm install check-dependencies --legacy-peer-deps
 fi
 
 # We suppress output for the next command because, annoyingly, it reports


### PR DESCRIPTION
Skyportal relies on baselayer, but has dependencies requiring both react v16 and v17 (see Issue https://github.com/skyportal/skyportal/issues/2656). Though ideally all deprecated React dependencies would be eliminated, this PR would in the interim allow both versions to be used concurrently.