### PR TITLE
Clean up after sessions in all handlers

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -96,6 +96,9 @@ class PSABaseHandler(RequestHandler):
                 exc_info=(typ, value, tb),
             )
 
+    def on_finish(self):
+        DBSession.remove()
+
 
 def bulk_verify(mode, collection, accessor):
     """Vectorized permission check for a heterogeneous set of records. If an
@@ -284,10 +287,6 @@ class BaseHandler(PSABaseHandler):
                 f"JSON decode of request body failed on {self.request.uri}."
                 " Please ensure all requests are of type application/json."
             )
-
-    def on_finish(self):
-        DBSession.remove()
-        return super().on_finish()
 
     def error(self, message, data={}, status=400, extra={}):
         """Push an error message to the frontend via WebSocket connection.


### PR DESCRIPTION
Before, session removal only happened on handlers deriving from
BaseHandler. This meant that the Python Social Auth handlers did not
do proper session removal upon error.