### PR TITLE
Select statements and Session

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -54,8 +54,7 @@ class PSABaseHandler(RequestHandler):
         user_id = self.user_id()
         oauth_uid = self.get_secure_cookie("user_oauth_uid")
         if user_id and oauth_uid:
-            # user = User.query.get(int(user_id))
-            with Session(user=None, verify=False) as session:
+            with DBSession() as session:
                 user = session.scalars(User.select(User.id == user_id)).first()
             if user is None:
                 return

--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -1,7 +1,7 @@
 import inspect
 import time
 import uuid
-from collections import defaultdict
+from contextlib import contextmanager
 from json.decoder import JSONDecodeError
 
 # The Python Social Auth base handler gives us:
@@ -11,7 +11,6 @@ from json.decoder import JSONDecodeError
 # and provides a cached version, `current_user`, that should
 # be used to look up the logged in user.
 import social_tornado.handlers as psa_handlers
-import sqlalchemy as sa
 import tornado.escape
 from tornado.log import app_log
 from tornado.web import RequestHandler
@@ -24,7 +23,7 @@ from ..custom_exceptions import AccessError
 from ..env import load_env
 from ..flow import Flow
 from ..json_util import to_json
-from ..models import DBSession, User, handle_inaccessible, session_context_id
+from ..models import DBSession, Session, User, bulk_verify, session_context_id
 
 env, cfg = load_env()
 log = make_log("basehandler")
@@ -55,7 +54,9 @@ class PSABaseHandler(RequestHandler):
         user_id = self.user_id()
         oauth_uid = self.get_secure_cookie("user_oauth_uid")
         if user_id and oauth_uid:
-            user = User.query.get(int(user_id))
+            # user = User.query.get(int(user_id))
+            with Session(user=None, verify=False) as session:
+                user = session.scalars(User.select(User.id == user_id)).first()
             if user is None:
                 return
             sa = user.social_auth.first()
@@ -98,60 +99,40 @@ class PSABaseHandler(RequestHandler):
             )
 
 
-def bulk_verify(mode, collection, accessor):
-    """Vectorized permission check for a heterogeneous set of records. If an
-    access leak is detected, it will be handled according to the `security`
-    section of the application's configuration.
-
-    Parameters
-    ----------
-    mode: str
-        The access mode to check. Can be create, read, update, or delete.
-    collection: collection of `baselayer.app.models.Base`.
-        The records to check. These records will be grouped by type, and
-        a single database query will be issued to check access for each
-        record type.
-    accessor: baselayer.app.models.User or baselayer.app.models.Token
-        The user or token to check.
-    """
-
-    grouped_collection = defaultdict(list)
-    for row in collection:
-        grouped_collection[type(row)].append(row)
-
-    # check all rows of the same type with a single database query
-    for record_cls, collection in grouped_collection.items():
-        collection_ids = {record.id for record in collection}
-
-        # vectorized query for ids of rows in the session that
-        # are accessible
-        accessible_row_ids_sq = record_cls.query_records_accessible_by(
-            accessor, mode=mode, columns=[record_cls.id]
-        ).subquery()
-
-        inaccessible_row_ids = DBSession().execute(
-            sa.select(record_cls.id)
-            .outerjoin(
-                accessible_row_ids_sq, record_cls.id == accessible_row_ids_sq.c.id
-            )
-            .where(record_cls.id.in_(collection_ids))
-            .where(accessible_row_ids_sq.c.id.is_(None))
-        )
-
-        # compare the accessible ids with the ids that are in the session
-        inaccessible_row_ids = {id for id, in inaccessible_row_ids}
-
-        # if any of the rows in the session are inaccessible, handle
-        if len(inaccessible_row_ids) > 0:
-            handle_inaccessible(mode, inaccessible_row_ids, record_cls, accessor)
-
-
 # Monkey-patch in each method of social_tornado.handlers.BaseHandler
 for (name, fn) in inspect.getmembers(PSABaseHandler, predicate=inspect.isfunction):
     setattr(psa_handlers.BaseHandler, name, fn)
 
 
 class BaseHandler(PSABaseHandler):
+    @contextmanager
+    def Session(self, verify=True):
+        """
+        Generate a scoped session that also has knowledge
+        of the current user, so when commit() is called on it
+        it will also verify that all rows being committed
+        are accessible to the user.
+        The current user is taken from the handler's `current_user`.
+        This is a shortcut method to `models.Session`
+        that saves the need to manually input the user object.
+
+        Parameters
+        ----------
+        verify : boolean
+            if True (default), will call the functions
+            `verify()` and whenever `commit()` is called.
+
+        Returns
+        -------
+        A scoped session object that can be used in a context
+        manager to access the database. If auto verify is enabled,
+        will use the current user given to apply verification
+        before every commit.
+
+        """
+        with Session(self.current_user, verify) as session:
+            yield session
+
     def verify_permissions(self):
         """Check that the current user has permission to create, read,
         update, or delete rows that are present in the session. If not,

--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -23,7 +23,7 @@ from ..custom_exceptions import AccessError
 from ..env import load_env
 from ..flow import Flow
 from ..json_util import to_json
-from ..models import DBSession, Session, User, bulk_verify, session_context_id
+from ..models import DBSession, User, VerifiedSession, bulk_verify, session_context_id
 
 env, cfg = load_env()
 log = make_log("basehandler")
@@ -132,7 +132,7 @@ class BaseHandler(PSABaseHandler):
         before every commit.
 
         """
-        with Session(self.current_user, verify) as session:
+        with VerifiedSession(self.current_user, verify) as session:
             yield session
 
     def verify_permissions(self):

--- a/app/models.py
+++ b/app/models.py
@@ -302,8 +302,9 @@ class Public(UserAccessControl):
         """
         # return only selected columns if requested
         if columns is not None:
-            return DBSession().query(*columns).select_from(cls)
-        return DBSession().query(cls)
+            return sa.select(*columns).select_from(cls)
+        else:
+            return sa.select(cls)
 
 
 public = Public()
@@ -369,9 +370,9 @@ class AccessibleIfUserMatches(UserAccessControl):
 
         # return only selected columns if requested
         if columns is not None:
-            query = DBSession().query(*columns).select_from(cls)
+            query = sa.select(*columns).select_from(cls)
         else:
-            query = DBSession().query(cls)
+            query = sa.select(cls)
 
         # traverse the relationship chain via sequential JOINs
         for relationship_name in self.relationship_names:
@@ -386,7 +387,7 @@ class AccessibleIfUserMatches(UserAccessControl):
 
         # filter for records with at least one matching user
         user_id = self.user_id_from_user_or_token(user_or_token)
-        query = query.filter(cls.id == user_id)
+        query = query.where(cls.id == user_id)
         return query
 
     @property
@@ -487,9 +488,9 @@ class AccessibleIfRelatedRowsAreAccessible(UserAccessControl):
 
         # return only selected columns if requested
         if columns is None:
-            base = DBSession().query(cls)
+            base = sa.select(cls)
         else:
-            base = DBSession().query(*columns).select_from(cls)
+            base = sa.select(*columns).select_from(cls)
 
         # ensure the target class has all the relationships referred to
         # in this instance
@@ -609,7 +610,7 @@ class ComposedAccessControl(UserAccessControl):
 
         # retrieve specified columns if requested
         if columns is not None:
-            query = DBSession().query(*columns).select_from(cls)
+            query = sa.select(*columns).select_from(cls)
         else:
             query = DBSession().query(cls)
 
@@ -654,7 +655,7 @@ class ComposedAccessControl(UserAccessControl):
         # in the case of or logic, require that only one of the conditions be
         # met for each row
         if self.logic == "or":
-            query = query.filter(
+            query = query.where(
                 sa.or_(*[col.isnot(None) for col in accessible_id_cols])
             )
 
@@ -690,10 +691,10 @@ class Restricted(UserAccessControl):
 
         # otherwise, all records are inaccessible
         if columns is not None:
-            return (
-                DBSession().query(*columns).select_from(cls).filter(sa.literal(False))
+            return DBSession().execute(
+                sa.select(*columns).select_from(cls).where(sa.literal(False))
             )
-        return DBSession().query(cls).filter(sa.literal(False))
+        return DBSession().execute(sa.select(cls).where(sa.literal(False)))
 
 
 restricted = Restricted()
@@ -791,7 +792,7 @@ class CustomUserAccessControl(UserAccessControl):
 
         # retrieve specified columns if requested
         if columns is not None:
-            query = query.with_entities(*columns)
+            query = sa.select(*columns).select_from(query.subquery())
 
         return query
 
@@ -825,14 +826,18 @@ class BaseMixin:
         logic = getattr(cls, mode)
 
         # Construct the join from which accessibility can be selected.
-        accessibility_target = (sa.func.count("*") > 0).label(f"{mode}_ok")
-        accessibility_table = logic.query_accessible_rows(
-            cls, user_or_token, columns=[accessibility_target]
-        ).filter(cls.id == self.id)
+        # accessibility_target = (sa.func.count("*") > 0).label(f"{mode}_ok")
+        accessibility_table = (
+            logic.query_accessible_rows(cls, user_or_token)
+            .where(cls.id == self.id)
+            .subquery()
+        )
+
+        query = sa.select(sa.func.count(accessibility_table.columns.id))
 
         # Query for the value of the access_func for this particular record and
         # return the result.
-        result = accessibility_table.scalar()
+        result = DBSession().execute(query).scalar_one() > 0
         if result is None:
             result = False
 
@@ -918,9 +923,15 @@ class BaseMixin:
             The records accessible to the specified user or token.
 
         """
-        return cls.query_records_accessible_by(
-            user_or_token, mode=mode, options=options, columns=columns
-        ).all()
+        return (
+            DBSession()
+            .execute(
+                cls.query_records_accessible_by(
+                    user_or_token, mode=mode, options=options, columns=columns
+                )
+            )
+            .all()
+        )
 
     @classmethod
     def query_records_accessible_by(
@@ -953,9 +964,10 @@ class BaseMixin:
             )
 
         logic = getattr(cls, mode)
-        return logic.query_accessible_rows(cls, user_or_token, columns=columns).options(
-            options
-        )
+        query = logic.query_accessible_rows(cls, user_or_token, columns=columns)
+        for option in options:
+            query = query.options(option)
+        return query
 
     query = DBSession.query_property()
     id = sa.Column(
@@ -1181,6 +1193,7 @@ class Role(Base):
         secondary="role_acls",
         passive_deletes=True,
         doc="ACLs associated with the Role.",
+        lazy="subquery",
     )
     users = relationship(
         "User",
@@ -1229,6 +1242,7 @@ class User(Base):
         back_populates="users",
         passive_deletes=True,
         doc="The roles assumed by this user.",
+        lazy="subquery",
     )
     role_ids = association_proxy(
         "roles",
@@ -1248,6 +1262,7 @@ class User(Base):
         secondary="user_acls",
         passive_deletes=True,
         doc="ACLs granted to user, separate from role-level ACLs",
+        lazy="subquery",
     )
     expiration_date = sa.Column(
         sa.DateTime,
@@ -1323,6 +1338,7 @@ class Token(Base):
         sa.ForeignKey("users.id", ondelete="CASCADE"),
         nullable=True,
         doc="The ID of the User that created the Token.",
+        lazy="subquery",
     )
     created_by = relationship(
         "User", back_populates="tokens", doc="The User that created the token."
@@ -1332,6 +1348,7 @@ class Token(Base):
         secondary="token_acls",
         passive_deletes=True,
         doc="The ACLs granted to the Token.",
+        lazy="subquery",
     )
     acl_ids = association_proxy("acls", "id", creator=lambda acl: ACL.query.get(acl))
     permissions = acl_ids

--- a/app/models.py
+++ b/app/models.py
@@ -60,9 +60,9 @@ class Session(sa.orm.session.Session):
         the user with a certain id. Example:
 
         with DBSession() as session:
-            user = session.execute(
+            user = session.scalars(
                 sa.select(User).where(User.id == user_id)
-            ).scalars().first()
+            ).first()
 
         Parameters
         ----------
@@ -1456,7 +1456,7 @@ class BaseMixin:
         standardized = np.atleast_1d(id_or_list)
         result = []
 
-        with Session(user_or_token) as session:
+        with DBSession() as session:
             # TODO: vectorize this
             for pk in standardized:
                 if options:
@@ -1508,7 +1508,7 @@ class BaseMixin:
             If columns is specified, will return a list of tuples
             containing the data from each column requested.
         """
-        with Session(user_or_token) as session:
+        with DBSession() as session:
             stmt = cls.select(user_or_token, mode, options, columns)
             values = session.scalars(stmt).all()
 

--- a/app/models.py
+++ b/app/models.py
@@ -31,11 +31,11 @@ session_context_id = contextvars.ContextVar("request_id", default=None)
 DBSession = scoped_session(sessionmaker(), scopefunc=session_context_id.get)
 
 
-class Session(sa.orm.session.Session):
+class _VerifiedSession(sa.orm.session.Session):
     """
     Create an instance of Session when you
     want to apply a verification method on all added
-    or modified or deleted rows before commiting them
+    or modified or deleted rows before committing them
     to the database.
 
     This class overrides the commit() function
@@ -48,7 +48,7 @@ class Session(sa.orm.session.Session):
 
     This will make sure the changes to the DB
     are verified, and will close the connection
-    when the context goes out.
+    when exiting of context.
 
     """
 
@@ -66,12 +66,13 @@ class Session(sa.orm.session.Session):
 
         Parameters
         ----------
-        user_or_token: baselayer.app.models.User object
+        user_or_token : baselayer.app.models.User object
             or baselayer.app.models.Token object.
             The object representing the current user.
 
         """
         self.user_or_token = user_or_token
+        super().__init__()
 
     def verify(self):
         """Check that the current user has permission to create, read,
@@ -119,7 +120,7 @@ class Session(sa.orm.session.Session):
 
 
 VerifiedSession = scoped_session(
-    sessionmaker(class_=Session), scopefunc=session_context_id.get
+    sessionmaker(class_=_VerifiedSession), scopefunc=session_context_id.get
 )
 
 
@@ -293,9 +294,9 @@ class UserAccessControl:
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The class to check.
-        attrs: list of str
+        attrs : list of str
             The names of the attributes to check for.
         """
         for attr in attrs:
@@ -312,7 +313,7 @@ class UserAccessControl:
 
         Parameters
         ----------
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
 
         Returns
@@ -338,17 +339,17 @@ class UserAccessControl:
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
         Returns
         -------
-        query: sqlalchemy.Query
+        query : sqlalchemy.Query
             Query for the accessible rows.
         """
 
@@ -360,11 +361,11 @@ class UserAccessControl:
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
@@ -453,17 +454,17 @@ class Public(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
         Returns
         -------
-        query: sqlalchemy.Query
+        query : sqlalchemy.Query
             Query for the accessible rows.
         """
         # return only selected columns if requested
@@ -477,11 +478,11 @@ class Public(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
@@ -541,17 +542,17 @@ class AccessibleIfUserMatches(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
         Returns
         -------
-        query: sqlalchemy.Query
+        query : sqlalchemy.Query
             Query for the accessible rows.
         """
 
@@ -587,11 +588,11 @@ class AccessibleIfUserMatches(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
@@ -709,17 +710,17 @@ class AccessibleIfRelatedRowsAreAccessible(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
         Returns
         -------
-        query: sqlalchemy.Query
+        query : sqlalchemy.Query
             Query for the accessible rows.
         """
 
@@ -773,11 +774,11 @@ class AccessibleIfRelatedRowsAreAccessible(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
@@ -896,17 +897,17 @@ class ComposedAccessControl(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
         Returns
         -------
-        query: sqlalchemy.Query
+        query : sqlalchemy.Query
             Query for the accessible rows.
         """
 
@@ -969,11 +970,11 @@ class ComposedAccessControl(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
@@ -1045,17 +1046,17 @@ class Restricted(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
         Returns
         -------
-        query: sqlalchemy.Query
+        query : sqlalchemy.Query
             Query for the accessible rows.
         """
 
@@ -1076,11 +1077,11 @@ class Restricted(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
@@ -1196,17 +1197,17 @@ class CustomUserAccessControl(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
         Returns
         -------
-        query: sqlalchemy.Query
+        query : sqlalchemy.Query
             Query for the accessible rows.
         """
 
@@ -1227,11 +1228,11 @@ class CustomUserAccessControl(UserAccessControl):
 
         Parameters
         ----------
-        cls: `baselayer.app.models.DeclarativeMeta`
+        cls : `baselayer.app.models.DeclarativeMeta`
             The mapped class of the target table.
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        columns: list of sqlalchemy.Column, optional, default None
+        columns : list of sqlalchemy.Column, optional, default None
             The columns to retrieve from the target table. If None, queries
             the mapped class directly and returns mapped instances.
 
@@ -1264,13 +1265,14 @@ class BaseMixin:
 
         Parameters
         ----------
-        user_or_token: `baselayer.app.models.User` or `baselayer.app.models.Token`
+        user_or_token : `baselayer.app.models.User` or `baselayer.app.models.Token`
             The User or Token to check.
-        mode: string
+        mode : string
             Type of access to check.
+
         Returns
         -------
-        accessible: bool
+        accessible : bool
             Whether the User or Token has the specified type of access to
             the record.
         """

--- a/app/models.py
+++ b/app/models.py
@@ -1338,7 +1338,6 @@ class Token(Base):
         sa.ForeignKey("users.id", ondelete="CASCADE"),
         nullable=True,
         doc="The ID of the User that created the Token.",
-        lazy="subquery",
     )
     created_by = relationship(
         "User", back_populates="tokens", doc="The User that created the token."


### PR DESCRIPTION
his PR introduces scoped sessions with user access verification.

It also introduces new methods on the Base model, to allow querying using the new "select" style compatible with SQLA 2.0

It also fixes the behavior of `get_if_accessible_by` to respond exactly the same if the row requested does not exist or if it is not accessible. 

This is mostly backward compatible, but a separate PR to skyportal fixes the few issues in the handlers and the tests that are broken by this change. 

Most importantly, it allows us to move each handler separately into the new SQLA 2.0 style without having to change everything at once. 