### PR TITLE
migration_manager: timestamp cache result after obtained, not before

### DIFF
--- a/services/migration_manager/migration_manager.py
+++ b/services/migration_manager/migration_manager.py
@@ -32,8 +32,8 @@ class timeout_cache:
         tic = self.lastrun
         toc = time.time()
         if (toc - tic) > self.timeout or self.cache is None:
-            self.lastrun = toc
             self.cache = self.func(*args, **kwargs)
+            self.lastrun = time.time()
 
         return self.cache
 


### PR DESCRIPTION
Otherwise the execution time is included in the cache timeout