### PR TITLE
Added user affiliation

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1809,6 +1809,7 @@ class User(Base):
 
     first_name = sa.Column(sa.String, nullable=True, doc="The User's first name.")
     last_name = sa.Column(sa.String, nullable=True, doc="The User's last name.")
+    affiliation = sa.Column(sa.String, nullable=True, doc="The User's affiliation.")
     contact_email = sa.Column(
         EmailType(),
         nullable=True,


### PR DESCRIPTION
This very short PR adds the user affiliation to the user model.
This field can be useful when publishing articles or writing circulars based on the science made by users.
A good example is writing GCN circulars on SkyPortal, where we will need the affiliation of users.