### PR TITLE
Fix baselayer tests

### DIFF
--- a/services/cron/cron.py
+++ b/services/cron/cron.py
@@ -14,7 +14,7 @@ from baselayer.log import make_log
 log = make_log("cron")
 
 env, cfg = load_env()
-jobs = cfg["cron"] or []
+jobs = cfg.get("cron", [])
 
 init_db(**cfg["database"])
 

--- a/tools/test_frontend.py
+++ b/tools/test_frontend.py
@@ -52,9 +52,10 @@ def verify_server_availability(url, timeout=60):
     """
     for i in range(timeout):
         try:
+            statuses, errcode = supervisor_status()
             assert (
                 all_services_running()
-            ), "Webservice(s) failed to launch:\n" + "\n".join(supervisor_status())
+            ), "Webservice(s) failed to launch:\n" + "\n".join(statuses)
             response = requests.get(url)
             assert response.status_code == 200, (
                 "Expected status 200, got" f" {response.status_code}" f" for URL {url}."


### PR DESCRIPTION
- Relied on `cfg['missing_key']` returning None; that behavior has
  been changed to be consistent with the Python dict
- Microservice error report was incorrectly passed to string formatter