### PR TITLE
Patch config get

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -60,18 +60,25 @@ class Config(dict):
 
     def __getitem__(self, key):
         keys = key.split(".")
-
-        val = self
-        for key in keys:
-            if isinstance(val, dict):
-                val = dict.__getitem__(val, key)
-            else:
-                # raise KeyError(key)
-                return None
-        return val
+        try:
+            val = self
+            for key in keys:
+                if isinstance(val, dict):
+                    val = dict.__getitem__(val, key)
+                else:
+                    raise KeyError(key)
+            return val
+        # patch until we change skyportal alongside this
+        # breaking change that raises KeyError instead of
+        # returning None
+        except KeyError:
+            return None
 
     def get(self, key, default=None, /):
         try:
+            # added "or default" to allow the change in
+            # the __getitem__ method to return None instead
+            # of raising KeyError
             return self.__getitem__(key) or default
         except KeyError:
             return default

--- a/app/config.py
+++ b/app/config.py
@@ -66,13 +66,13 @@ class Config(dict):
             if isinstance(val, dict):
                 val = dict.__getitem__(val, key)
             else:
-                raise KeyError(key)
-
+                # raise KeyError(key)
+                return None
         return val
 
     def get(self, key, default=None, /):
         try:
-            return self.__getitem__(key)
+            return self.__getitem__(key) or default
         except KeyError:
             return default
 


### PR DESCRIPTION
The new changes in `app/config.py` make the behavior of the config more consistent with python dictionaries:
- when using `cfg['some_key']` it raises a `KeyError` if not found. 
- using `cfg.get('some_key')` will return `None` or whatever default was specified.
This is a good thing to have, but requires changing many, many files in skyportal. 
I suggest this patch for now, which still allows using `cfg.get()` with a default (or return `None`) but leaves the `gcf['...']` as it was before. 
An accompanying PR to revert these changes can be made after all the relevant places in skyportal are migrated to using `cfg.get()`. 