### PR TITLE
Have status_server return 200 when starting

### DIFF
--- a/services/status_server/status_server.py
+++ b/services/status_server/status_server.py
@@ -8,14 +8,14 @@ env, cfg = load_env()
 
 class MainHandler(tornado.web.RequestHandler):
     def get(self):
-        self.set_status(503)
+        self.set_status(200)
         self.write(f"<h2>{cfg['app.title']} is being provisioned</h2>")
 
 
 class MainAPIHandler(tornado.web.RequestHandler):
     def get(self, args):
         self.set_header("Content-Type", "application/json")
-        self.set_status(503)
+        self.set_status(200)
         self.write(
             {
                 "status": "error",


### PR DESCRIPTION
This PR modifies status_server to return 200's instead of 503's based on the GCP warnings: "Unhealthy
Readiness probe failed: HTTP probe failed with statuscode: 503".