### PR TITLE
Add request_length to nginx log

### DIFF
--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -105,7 +105,7 @@ http {
     "~*(?P<tr>.{0,14}).*" $tr;
   }
 
-  log_format elb_log '$remote_addr - $remote_user [$trunc_authorization] [$time_local] ' '"$request" $status $body_bytes_sent $request_length "$http_referer" ' '"$http_user_agent"';
+  log_format elb_log '$remote_addr - $remote_user [$trunc_authorization] [$time_local] ' '"$request" $status $body_bytes_sent rl=$request_length "$http_referer" ' '"$http_user_agent"';
 
   server {
     {% if env.debug %}

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -105,7 +105,7 @@ http {
     "~*(?P<tr>.{0,14}).*" $tr;
   }
 
-  log_format elb_log '$remote_addr - $remote_user [$trunc_authorization] [$time_local] ' '"$request" $status $body_bytes_sent "$http_referer" ' '"$http_user_agent"';
+  log_format elb_log '$remote_addr - $remote_user [$trunc_authorization] [$time_local] ' '"$request" $status $body_bytes_sent $request_length "$http_referer" ' '"$http_user_agent"';
 
   server {
     {% if env.debug %}


### PR DESCRIPTION
This PR adds request_length to nginx log, which should allow us to track query sizes by IP. See e.g. https://www.ruby-forum.com/t/logging-variables-bytes-sent-where-is-bytes-read/241597/8.