### PR TITLE
cron: do not fail if a job entry is empty

### DIFF
--- a/services/cron/cron.py
+++ b/services/cron/cron.py
@@ -70,6 +70,8 @@ tc = TimeCache()
 
 while True:
     for job in jobs:
+        if job["interval"] is None:
+            continue
         interval = job["interval"]
         script = job["script"]
         limit = job.get("limit")


### PR DESCRIPTION
skips over jobs that are in the config but missing key parameters.