### PR TITLE
Return 404 rather than throw app error

### DIFF
--- a/app/access.py
+++ b/app/access.py
@@ -72,7 +72,14 @@ def permissions(acl_list):
                 or "System admin" in self.current_user.permissions
             ):
                 raise tornado.web.HTTPError(401)
-            return method(self, *args, **kwargs)
+            print(method, args, kwargs)
+            try:
+                return method(self, *args, **kwargs)
+            except TypeError as e:
+                raise tornado.web.HTTPError(
+                    404,
+                    f"Query exception occured: {str(e)}",
+                )
 
         return wrapper
 


### PR DESCRIPTION
This PR returns 404 rather than throw app error in case of bad query.

See https://github.com/skyportal/skyportal/issues/3603