### PR TITLE
Modify Nginx max request body size (from client) in the config

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -39,6 +39,9 @@ server:
     # frontend only (i.e., no token authorized API requests)
     dedicated_frontend_processes: 2
 
+    # The max size of a request body in megabytes (M)
+    max_body_size: 10
+
     # Rate limit: number of requests per second (see https://www.nginx.com/blog/rate-limiting-nginx/)
     rate_limit: 5
 

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -114,7 +114,7 @@ http {
     listen {{ ports.app }};
     listen {{ ports.app_http_proxy }} proxy_protocol; # This is for AWS Elastic Load Balancer
     {% endif %}
-    client_max_body_size 10M;
+    client_max_body_size {{ server.max_body_size }}M;
 
     location / {
       # API rate limiting


### PR DESCRIPTION
This PR allows us to modify the max request body size from the config file of the baselayer.
This is needed in some instances of SkyPortal where we need to upload .fits file (for analysis, or as comment attachments).
Of course, after a first review to figure out if anything should be done differently, it will be followed by an associated PR on SkyPortal main.