### PR TITLE
Fix double selenium-requests requirement

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
       - id: black
         pass_filenames: true
         exclude: baselayer|node_modules|static
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.8.4
     hooks:
       - id: flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ sqlalchemy-utils>=0.36.8
 social-auth-core==4.2.0
 social-auth-app-tornado>=1.0.0
 social-auth-storage-sqlalchemy>=1.1.0
-selenium-requests>=1.4
 arrow>=0.15.4
 jinja2>=2.11.2
 python-dateutil>=2.8.1


### PR DESCRIPTION
This PR removes a double requirement for `selenium-requests`, keeping the newer version.