### PR TITLE
Support JSON serialization of ObjectId

### DIFF
--- a/app/json_util.py
+++ b/app/json_util.py
@@ -2,6 +2,7 @@ from datetime import date, datetime
 
 import simplejson as json
 from arrow.arrow import Arrow
+from bson import ObjectId
 from sqlalchemy_utils import PhoneNumber
 
 data_types = {
@@ -42,6 +43,9 @@ class Encoder(json.JSONEncoder):
 
         elif isinstance(o, PhoneNumber):
             return o.e164
+        
+        elif isinstance(o, ObjectId):
+            return str(o)
 
         elif type(o) is type and o in data_types:
             return data_types[o]

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ python-dateutil>=2.8.1
 phonenumbers>=8.12.15
 python-slugify>=4.0.1
 numpy>=1.21.4
+pymongo>=1.9


### PR DESCRIPTION
This PR adds the support for ObjectId serialization. For any application using baselayer and interacting with MongoDB, not supporting ObjectId serialization means having to add acustom method pre serialization to convert it to string. It would be helpful to support it in Baselayer directly.