### PR TITLE
Add kwargs to to_json

### DIFF
--- a/app/json_util.py
+++ b/app/json_util.py
@@ -52,5 +52,5 @@ class Encoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, o)
 
 
-def to_json(obj):
-    return json.dumps(obj, cls=Encoder, indent=2, ignore_nan=True)
+def to_json(obj, **kwargs):
+    return json.dumps(obj, cls=Encoder, indent=2, ignore_nan=True, **kwargs)

--- a/app/json_util.py
+++ b/app/json_util.py
@@ -53,4 +53,5 @@ class Encoder(json.JSONEncoder):
 
 
 def to_json(obj, **kwargs):
-    return json.dumps(obj, cls=Encoder, indent=2, ignore_nan=True, **kwargs)
+    indent = kwargs.pop("indent", 2)
+    return json.dumps(obj, cls=Encoder, indent=indent, ignore_nan=True, **kwargs)


### PR DESCRIPTION
This PR adds a kwargs to to_json, useful for using to_json as a drop-in replacement for json.dumps (which it is, but will benefit from taking the various optional args).