### PR TITLE
WIP - Service plugins

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -156,3 +156,5 @@ security:
 #   - interval: 5
 #     script: tools/5_minute.py
 #     limit: ["01:00", "02:00"]
+
+plugins:

--- a/tools/setup_services.py
+++ b/tools/setup_services.py
@@ -1,12 +1,59 @@
 import os
 from collections import Counter
 from os.path import join as pjoin
+import subprocess
 
 from baselayer.app.env import load_env
 from baselayer.log import make_log
 
 log = make_log("baselayer")
 
+def download_plugin_services():
+    env, cfg = load_env()
+
+    services_path = cfg["services.paths"]
+
+    plugins = cfg.get("plugins", {})
+    plugin_services = []
+
+    log(f"Discovered {len(plugins)} plugins")
+
+    for plugin_name, plugin_info in plugins.items():
+        if "url" not in plugin_info:
+            log(f"Skipping plugin {plugin_name} because it has no URL")
+            continue
+
+        git_repo = plugin_info["url"].split(".git")[0].split("/")[-1]
+        plugin_path = pjoin(services_path[-1], git_repo)
+
+        if os.path.exists(plugin_path):
+            if os.path.exists(pjoin(plugin_path, ".git")):
+                log(f"Updating plugin {plugin_name}")
+                _, stderr = subprocess.Popen(
+                    f"cd {plugin_path} && git pull",
+                    shell=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                ).communicate()
+                if stderr and len(stderr) > 0:
+                    log(f"Error updating plugin {plugin_name}: {stderr}")
+                    continue
+            else:
+                log(f"Skipping plugin {plugin_name} because a microservice with the same name exists at {plugin_path}")
+            continue
+        else:
+            log(f"Cloning plugin {plugin_name}")
+            _, stderr = subprocess.Popen(
+                f"cd {services_path[-1]} && git clone {plugin_info['url']}",
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ).communicate()
+            if stderr and len(stderr) > 0:
+                log(f"Error cloning plugin {plugin_name}: {stderr}")
+                continue
+        plugin_services.append(plugin_name)
+    return plugin_services
 
 def copy_supervisor_configs():
     env, cfg = load_env()
@@ -56,4 +103,6 @@ def copy_supervisor_configs():
 
 
 if __name__ == "__main__":
+    download_plugin_services()
+    print()
     copy_supervisor_configs()


### PR DESCRIPTION
Just a quick experiment with plug-and-play microservices. Other instances of SkyPortal (such as Icare, used by GRANDMA) have some custom microservices. It's a little awkward that they have to maintain their special architecture to get just one microservice running.

This is just an idea of how we could allow one to add as many custom microservices as needed with just a few lines added to baselayer.

And, here's the demo repo that shows what a git repo for a custom microservice needs to look like.

Definitely a WIP, but it works perfectly as is.