### PR TITLE
webdriver-manager

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,12 @@ jobs:
           cd baselayer
 
           sudo apt update -y
+
+          ### firefox installation
+          sudo snap remove firefox
+          sudo add-apt-repository ppa:mozillateam/ppa
+          printf 'Package: *\nPin: release o=LP-PPA-mozillateam\nPin-Priority: 1001' | sudo tee /etc/apt/preferences.d/mozilla-firefox
+
           sudo apt install -y wget nodejs unzip firefox nginx
 
           pip install --upgrade pip

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,7 @@ jobs:
 
       - name: Install Geckodriver / Selenium
         run: |
-          GECKO_VER=0.30.0
+          GECKO_VER=0.34.0
           CACHED_DOWNLOAD_DIR=~/.local/downloads
           FILENAME=geckodriver-v${GECKO_VER}-linux64.tar.gz
 

--- a/app/test_util.py
+++ b/app/test_util.py
@@ -145,6 +145,7 @@ class MyCustomWebDriver(RequestsSessionMixin, webdriver.Firefox):
 @pytest.fixture(scope="session")
 def driver(request):
     from selenium import webdriver
+    from webdriver_manager.firefox import GeckoDriverManager
 
     options = webdriver.FirefoxOptions()
     if "BASELAYER_TEST_HEADLESS" in os.environ:
@@ -163,7 +164,10 @@ def driver(request):
         ),
     )
 
-    driver = MyCustomWebDriver(options=options)
+    service = webdriver.firefox.service.Service(
+        executable_path=GeckoDriverManager().install()
+    )
+    driver = MyCustomWebDriver(options=options, service=service)
     driver.set_window_size(1920, 1200)
     login(driver)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ python-dateutil>=2.8.1
 phonenumbers>=8.12.15
 python-slugify>=4.0.1
 numpy>=1.21.4
+webdriver-manager>=4.0.1


### PR DESCRIPTION
This PR adds webdriver-manager to deal with GeckoDriver (see https://stackoverflow.com/questions/46753393/how-to-run-headless-firefox-with-selenium-in-python, as my upgrade to Sonoma broke it).