### PR TITLE
Notification data-testid

### DIFF
--- a/static/js/components/Notifications.jsx
+++ b/static/js/components/Notifications.jsx
@@ -63,6 +63,7 @@ export const Notifications = () => {
         {notifications.map((notification) => (
           <div
             key={notification.id}
+            data-testid={`notification-${notification.id}`}
             style={{ ...style.note, background: noteColor[notification.type] }}
             onClick={() => dispatch(hideNotification(notification.id))}
           >


### PR DESCRIPTION
Some of SkyPortal tests are flaky and/or require extra retry logic because some of the baselayer <Notification> appear on top of elements we are trying to click. A good example is the weather widget, which during testing might request for a telescope fixture that has been deleted. That yields an error that displays as a notification. But for some tests like the dashboard or quick search bar, this notification overlaps with things we want to click. So the click happens, but clicks on the notification and that breaks the rest of the test.

A simple way to figure out if these notifications are there so that we can make them go away is to give them a data-testid that contains `notification` in it.

This PR does just that.