### PR TITLE
Nginx conf: list <server> SSL only if a certificate is used

### DIFF
--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -20,8 +20,11 @@ paths:
     downloads_folder: '/tmp'
 
 server:
-    # If your server is expected to be accessed with https and not http,
-    # then set this to True
+    # Set this to true if the URL of your server is expected to be secure, i.e.
+    # https://...
+    # E.g., if you are using an HTTPS load balancer, this value will likely be true.
+    #
+    # Also see `ssl_certificate` for running nginx in SSL mode. 
     ssl: False
 
     # If you are using certificates, you can specify them here

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -24,7 +24,7 @@ server:
     # https://...
     # E.g., if you are using an HTTPS load balancer, this value will likely be true.
     #
-    # Also see `ssl_certificate` for running nginx in SSL mode. 
+    # Also see `ssl_certificate` for running nginx in SSL mode.
     ssl: False
 
     # If you are using certificates, you can specify them here

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -26,7 +26,6 @@ server:
 
     # If you are using certificates, you can specify them here
     # See http://nginx.org/en/docs/http/configuring_https_servers.html for details
-    ssl_use_certificate: False
     ssl_certificate:
     ssl_certificate_key:
 

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -20,10 +20,8 @@ paths:
     downloads_folder: '/tmp'
 
 server:
-    # Whether the base URL is http or https
-    #
-    # If you are behind a load balancer that connects to the app via http,
-    # this should be set to False.
+    # If your server is expected to be accessed with https and not http,
+    # then set this to True
     ssl: False
 
     # If you are using certificates, you can specify them here

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -111,7 +111,7 @@ http {
     {% if env.debug %}
     listen 127.0.0.1:{{ ports.app }};
     {% else %}
-    {% if server.ssl_use_certificate %}
+    {% if server.ssl_certificate %}
     listen {{ ports.app }} ssl;
     {% else %}
     listen {{ ports.app }};
@@ -120,7 +120,7 @@ http {
     {% endif %}
     client_max_body_size {{ server.max_body_size }}M;
 
-    {% if server.ssl_use_certificate %}
+    {% if server.ssl_certificate %}
     ssl_certificate {{ server.ssl_certificate }};
     ssl_certificate_key {{ server.ssl_certificate_key }};
     {% endif %}

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -111,7 +111,7 @@ http {
     {% if env.debug %}
     listen 127.0.0.1:{{ ports.app }};
     {% else %}
-    {% if server.ssl %}
+    {% if server.ssl_use_certificate %}
     listen {{ ports.app }} ssl;
     {% else %}
     listen {{ ports.app }};


### PR DESCRIPTION
The current configuration is incorrect. In the app, the `ssl` key of the config is used to figure out if the server should be accessed with https (if True) or http (if False), and not whether or not nginx should use an SSL certificate. For that, we have the `use_ssl_certificate` key already present in the default config.