### PR TITLE
Query accessible records: SQLAlchemy 2.0 syntax

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,11 +74,13 @@ jobs:
           sudo apt install -y wget nodejs unzip firefox
 
           # if nginx is already installed, remove it
-          sudo apt remove -y nginx nginx-common nginx-core
+          sudo apt remove -y nginx nginx-common nginx-core nginx-full
+          sudo apt purge -y nginx nginx-common nginx-core nginx-full
 
-          sudo add-apt-repository ppa:ondrej/nginx-mainline -y
+          # add the PPA repository with brotli support for nginx
+          sudo add-apt-repository ppa:ondrej/nginx -y
           sudo apt update -y
-          sudo apt install -y nginx libnginx-mod-brotli
+          sudo apt install nginx libnginx-mod-http-brotli-static libnginx-mod-http-brotli-filter -y
 
 
           pip install --upgrade pip

--- a/app/models.py
+++ b/app/models.py
@@ -14,7 +14,13 @@ from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.associationproxy import association_proxy
 from sqlalchemy.ext.declarative import declared_attr
-from sqlalchemy.orm import declarative_base, relationship, scoped_session, sessionmaker
+from sqlalchemy.orm import (
+    declarative_base,
+    load_only,
+    relationship,
+    scoped_session,
+    sessionmaker,
+)
 from sqlalchemy_utils import EmailType, PhoneNumberType
 
 from .custom_exceptions import AccessError
@@ -1226,7 +1232,7 @@ class CustomUserAccessControl(UserAccessControl):
             # here query is not of type sqlalchemy.Query, but sqlalchemy.Select
             # so we use the appropriate method to retrieve the columns
             if columns is not None:
-                query = query.with_only_columns(*columns)
+                query = query.options(load_only(*columns))
 
         return query
 


### PR DESCRIPTION
I noticed that when using the sqlachemy 2.0 syntax to create `CustomUserAccessControl`s on a table, I couldn't commit().

This is because commit() calls a method that only supported the `sa.Query` type of objects, and not the new `sa.Select` that you are expected to use in SQLAlchemy 2.0