### PR TITLE
Websocket Frontend Notifications: specify duration

### DIFF
--- a/static/js/MessageHandler.js
+++ b/static/js/MessageHandler.js
@@ -34,7 +34,12 @@ class MessageHandler {
 const notificationHandler = (actionType, payload, dispatch) => {
   if (actionType === SHOW_NOTIFICATION) {
     const { note, type } = payload;
-    dispatch(showNotification(note, type));
+    let { duration } = payload;
+    // if the duration is missing or invalid (negative or too large), use the default
+    if (!duration || duration <= 0 || duration >= 30000) {
+      duration = 3000;
+    }
+    dispatch(showNotification(note, type, duration));
   }
 };
 


### PR DESCRIPTION
Users have often complained that some notifications were too hard to read because of the short 3 seconds we have by default. We might want to change that default altogether, but it seems like a good idea to let the developer specify a longer duration from the backend if needed (when sending the websocket notification), depending on how long the `note` that will be displayed is.

This PR modifies the existing `notificationHandler` to try and grab a duration from the websocket payload, and set it to the default 3 seconds if:
- it is missing
- it is equal or lower than 0
- it is higher than 30 seconds