### PR TITLE
User: bio and bot flag

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1876,7 +1876,7 @@ class User(Base):
     preferences = sa.Column(
         JSONB, nullable=True, doc="The user's application settings."
     )
-    bot = sa.Column(
+    is_bot = sa.Column(
         sa.Boolean,
         nullable=False,
         server_default="false",

--- a/app/models.py
+++ b/app/models.py
@@ -1851,6 +1851,11 @@ class User(Base):
 
     first_name = sa.Column(sa.String, nullable=True, doc="The User's first name.")
     last_name = sa.Column(sa.String, nullable=True, doc="The User's last name.")
+    bio = sa.Column(
+        sa.String,
+        nullable=True,
+        doc="A short biography of the user, or description for bot accounts.",
+    )
     affiliations = sa.Column(
         sa.ARRAY(sa.String),
         nullable=False,
@@ -1870,6 +1875,12 @@ class User(Base):
     oauth_uid = sa.Column(sa.String, unique=True, doc="The user's OAuth UID.")
     preferences = sa.Column(
         JSONB, nullable=True, doc="The user's application settings."
+    )
+    bot = sa.Column(
+        sa.Boolean,
+        nullable=False,
+        server_default="false",
+        doc="Whether the user is a bot account.",
     )
 
     roles = relationship(

--- a/app/models.py
+++ b/app/models.py
@@ -1880,7 +1880,7 @@ class User(Base):
         sa.Boolean,
         nullable=False,
         server_default="false",
-        doc="Whether the user is a bot account.",
+        doc="Whether or not the user account should be flagged as a bot account.",
     )
 
     roles = relationship(


### PR DESCRIPTION
The idea of this PR is to add a bio field to the user model, as well as a bot flag (maybe should be renamed to `is_bot` to make the boolean-ness more obvious where we use it???).

it's nice in general to have a field for a user to store a bio that other users could access, and this will come in handy for a couple of applications:
- we're considering a public user profile page, where other users that are in any of your groups (except public of course, as all users are there) can see your user profile's most basic info, as well as some kind of activity tracker similar to the news feed but only for a given user.
- for the TNS reporting, before we can let bot accounts report to the Transient Name Server autonomously (needed for BTSbot), we need to be able to mark bot accounts as such (hence the new flag), but also have some kind of remark added to the TNS report, which would be that `bio` field for a bot account.

Naturally, this will be followed by a SkyPortal PR which code is already written (the PR will be opened once this is merge to main).