### PR TITLE
check for geckodriver binary before bothering to install it

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,10 @@ jobs:
             ~/.cache/pip
           key: ${{ runner.os }}-${{ hashFiles('**/requirements*.txt') }}
 
+      - uses: browser-actions/setup-geckodriver@latest
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install system dependencies
         run: |
           cd baselayer
@@ -100,14 +104,6 @@ jobs:
 
       - name: Install Geckodriver / Selenium
         run: |
-          GECKO_VER=0.34.0
-          CACHED_DOWNLOAD_DIR=~/.local/downloads
-          FILENAME=geckodriver-v${GECKO_VER}-linux64.tar.gz
-
-          if [[ ! -f ${CACHED_DOWNLOAD_DIR=}/${FILENAME} ]]; then
-            wget https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VER}/${FILENAME} --directory-prefix=${CACHED_DOWNLOAD_DIR} --no-clobber
-          fi
-          sudo tar -xzf ${CACHED_DOWNLOAD_DIR}/geckodriver-v${GECKO_VER}-linux64.tar.gz -C /usr/local/bin
           geckodriver --version
           pip install selenium==4.8.3
           python -c "import selenium; print(f'Selenium {selenium.__version__}')"

--- a/app/test_util.py
+++ b/app/test_util.py
@@ -144,6 +144,8 @@ class MyCustomWebDriver(RequestsSessionMixin, webdriver.Firefox):
 
 @pytest.fixture(scope="session")
 def driver(request):
+    import shutil
+
     from selenium import webdriver
     from webdriver_manager.firefox import GeckoDriverManager
 
@@ -164,9 +166,11 @@ def driver(request):
         ),
     )
 
-    service = webdriver.firefox.service.Service(
-        executable_path=GeckoDriverManager().install()
-    )
+    executable_path = shutil.which("geckodriver")
+    if executable_path is None:
+        executable_path = GeckoDriverManager().install()
+    service = webdriver.firefox.service.Service(executable_path=executable_path)
+
     driver = MyCustomWebDriver(options=options, service=service)
     driver.set_window_size(1920, 1200)
     login(driver)


### PR DESCRIPTION
This PR checks for geckodriver binary before bothering to install it and avoids some requests that seem to be overwhelming the GA.