### PR TITLE
auth_or_token decorator: set __authenticated__=True attribute

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -14,7 +14,7 @@ jobs:
     if: github.repository_owner == 'cesium-ml'
 
     steps:
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
 
       - uses: actions/checkout@v4
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,9 +34,9 @@ jobs:
     steps:
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.12"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: 20
 
@@ -48,13 +48,13 @@ jobs:
           git clone https://github.com/cesium-ml/baselayer_template_app
           cp -rf baselayer baselayer_template_app/
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('baselayer_template_app/package.json') }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.cache/pip
@@ -147,7 +147,7 @@ jobs:
           make test_headless
 
       - name: Upload logs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: ${{ always() }}
         with:
           name: logs

--- a/app/access.py
+++ b/app/access.py
@@ -55,6 +55,7 @@ def auth_or_token(method):
                 )
             return tornado.web.authenticated(method)(self, *args, **kwargs)
 
+    wrapper.__authenticated__ = True
     return wrapper
 
 


### PR DESCRIPTION
add an __authenticated__=True attribute to handler methods that require auth, so we can use it when autogenerating the openapi specs and show/hide token auth headers in the auto-generated code examples.

Required for us to then merge https://github.com/skyportal/skyportal/pull/5273