### PR TITLE
@permissions decorated handlers: add a __permissions__ attr

### DIFF
--- a/app/access.py
+++ b/app/access.py
@@ -75,6 +75,7 @@ def permissions(acl_list):
                 raise tornado.web.HTTPError(401)
             return method(self, *args, **kwargs)
 
+        wrapper.__permissions__ = acl_list
         return wrapper
 
     return check_acls


### PR DESCRIPTION
add a __permissions__ attr to the handlers we wrap in the `@permissions([...])` decorator, so that on import (of the decorated methods) we can easily figure out what permissions an endpoint might need.

Will come in handy when skyportal auto generates the open API specifications, so we can inject a list of required permissions to be displayed in the API docs