### PR TITLE
Remove some warnings (sqlalchemy & selenium)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1894,7 +1894,7 @@ class User(Base):
     role_ids = association_proxy(
         "roles",
         "id",
-        creator=lambda r: DBSession().query(Role).get(r),
+        creator=lambda r: DBSession().scalar(sa.select(Role).where(Role.id == r)),
     )
     tokens = relationship(
         "Token",
@@ -2000,7 +2000,9 @@ class Token(Base):
         lazy="selectin",
     )
     acl_ids = association_proxy(
-        "acls", "id", creator=lambda acl: DBSession().query(ACL).get(acl)
+        "acls",
+        "id",
+        creator=lambda acl: DBSession().scalar(sa.select(ACL).where(ACL.id == acl)),
     )
     permissions = acl_ids
 

--- a/app/test_util.py
+++ b/app/test_util.py
@@ -151,7 +151,7 @@ def driver(request):
 
     options = webdriver.FirefoxOptions()
     if "BASELAYER_TEST_HEADLESS" in os.environ:
-        options.headless = True
+        options.add_argument("-headless")
     options.set_preference("devtools.console.stdout.content", True)
     options.set_preference("browser.download.manager.showWhenStarting", False)
     options.set_preference("browser.download.folderList", 2)


### PR DESCRIPTION
This PR addresses 2 warnings I kept seeing when running the CI of SkyPortal:
- the selenium config complaining about how we ask it to run headless (current way we do it is deprecated)
- some sqlalchemy code in `app/models.py` complaining about the `.query(...).get(...)` (the `get` is the issue, deprecated)

PS: There are still a couple of places where we have this `.query(...).get(...)` pattern that I did not remove here, namely we have this `def create_or_get(cls, id):` which I'm not a huge fan of. It's not used anywhere in baselayer, just once in SkyPortal and it could be replaced by a more explicit "does this entry exist in the DB? If not create it" logic. I don't really like the "magic" of this function where if something doesn't exist it still gets returned, but what if one does not `commit()` after calling it, then it only exists temporarily but one could easily not notice that.