### PR TITLE
Add group accessible function for User and Token

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1946,6 +1946,23 @@ class User(Base):
         """The base model for User subclasses."""
         return User
 
+    def assert_group_accessible(self, group_id):
+        """Raise an error if the user or token does not have access to the given group.
+
+        Parameters
+        ----------
+        group_id : int or str
+            The ID of the group to check.
+
+        Raises
+        ------
+        AccessError
+            If the user or token does not have access to the group.
+        """
+        accessible_group_ids = {group.id for group in self.groups}
+        if not is_admin(self) and int(group_id) not in accessible_group_ids:
+            raise AccessError(f"Group {group_id} is not accessible by the current user.")
+
     def is_authenticated(self):
         """Boolean flag indicating whether the User is currently
         authenticated."""

--- a/static/js/components/Notifications.jsx
+++ b/static/js/components/Notifications.jsx
@@ -35,23 +35,23 @@ export const Notifications = () => {
 
     note: {
       color: "white",
-      fontWeight: "bold",
-      paddingTop: "0.8em",
-      paddingBottom: "0.8em",
-      paddingLeft: "1em",
-      marginBottom: 5,
+      fontWeight: 600,
+      padding: "1em 1.3em",
+      marginBottom: "0.5em",
       width: "100%",
+      borderRadius: "8px",
+      WebkitBoxShadow: "0 4px 5px rgba(0, 0, 0, 0.2)",
+      MozBoxShadow: "0 4px 5px rgba(0, 0, 0, 0.2)",
+      boxShadow: "0 4px 5px rgba(0, 0, 0, 0.2)",
+      fontSize: "0.95rem",
       display: "inline-block",
-      WebkitBoxShadow: "0 0 5px black",
-      MozBoxShadow: "0 0 5px black",
-      boxShadow: "0 0 5px black",
     },
   };
 
   const noteColor = {
-    error: "Crimson",
-    warning: "Orange",
-    info: "MediumAquaMarine",
+    error: "rgba(244,67,54,0.95)",
+    warning: "rgba(255,152,0,0.95)",
+    info: "rgba(11,181,119,0.95)",
   };
 
   const dispatch = useDispatch();

--- a/static/js/components/Notifications.jsx
+++ b/static/js/components/Notifications.jsx
@@ -36,7 +36,7 @@ export const Notifications = () => {
     note: {
       color: "white",
       fontWeight: 600,
-      padding: "1em 1.3em",
+      padding: "1.3em",
       marginBottom: "0.5em",
       width: "100%",
       borderRadius: "8px",


### PR DESCRIPTION
This PR introduces the AccessVerificationMixin to centralize access checks for both User and Token models.
It also adds a reusable assert_group_accessible method to easily check whether a user (or token) can access a given group, which are performed frequently throughout SkyPortal. This refactor helps clean up redundant skyportal codes, and for me it makes sense to put it here.