### PR TITLE
Javascript package installer version check + lower min node version requirement

### DIFF
--- a/tools/check_app_environment.py
+++ b/tools/check_app_environment.py
@@ -16,7 +16,7 @@ def output(cmd):
     return success, out
 
 
-js_installer = get_js_installer()
+js_installer, js_installer_version = get_js_installer()
 
 deps = {
     "nginx": (
@@ -32,8 +32,12 @@ deps = {
         lambda v: v.split("\n")[-1].split()[2],
         "12.0",
     ),
-    js_installer: ([js_installer, "-v"], lambda v: v, "0.0.0"),
-    "node": (["node", "-v"], lambda v: v[1:], "22.0.0"),
+    js_installer: (
+        [js_installer, "--version"],
+        lambda v: v.strip(),
+        js_installer_version if js_installer_version is not None else "0.0.0",
+    ),
+    "node": (["node", "-v"], lambda v: v[1:], "20.0.0"),
     "python": (["python", "--version"], lambda v: v.split()[1], "3.8"),
 }
 

--- a/tools/get_js_installer.py
+++ b/tools/get_js_installer.py
@@ -24,4 +24,5 @@ def get_js_installer():
 
 
 if __name__ == "__main__":
-    print(get_js_installer())
+    installer, version = get_js_installer()
+    print(installer)

--- a/tools/get_js_installer.py
+++ b/tools/get_js_installer.py
@@ -10,11 +10,17 @@ def get_js_installer():
         data = {}
 
     packageManager = data.get("packageManager", "npm@")
+    packageManagerVersion = None
     managers = ("pnpm", "yarn", "bun", "npm")
 
+    if packageManager.count("@") == 1:
+        parts = packageManager.split("@")
+        packageManager = parts[0]
+        packageManagerVersion = parts[1] if len(parts) > 1 else None
+
     for manager in managers:
-        if manager in packageManager:
-            return manager
+        if packageManager.startswith(manager):
+            return manager, packageManagerVersion
 
 
 if __name__ == "__main__":

--- a/tools/get_js_installer.py
+++ b/tools/get_js_installer.py
@@ -16,7 +16,7 @@ def get_js_installer():
     if packageManager.count("@") == 1:
         parts = packageManager.split("@")
         packageManager = parts[0]
-        packageManagerVersion = parts[1] if len(parts) > 1 else None
+        packageManagerVersion = parts[1].strip() if len(parts.strip()) > 1 else None
 
     for manager in managers:
         if packageManager.startswith(manager):

--- a/tools/get_js_installer.py
+++ b/tools/get_js_installer.py
@@ -16,7 +16,7 @@ def get_js_installer():
     if packageManager.count("@") == 1:
         parts = packageManager.split("@")
         packageManager = parts[0]
-        packageManagerVersion = parts[1].strip() if len(parts.strip()) > 1 else None
+        packageManagerVersion = parts[1].strip() if len(parts[1].strip()) > 1 else None
 
     for manager in managers:
         if packageManager.startswith(manager):


### PR DESCRIPTION
* lower the min node version required. I don't see why we updated this to 22 (from 20), given that I really don't think we rely on features that 22 has and 20 hasn't. Other than if we have known failures or security reasons, upgrading these things should not be done, so we don't break things for users downstream.
* read the package manager version and not just the package manager name, and have it verified in `check_app_environment.py`. It looks like with the current version of baselayer, that was ignored