### PR TITLE
Extensions: clone with --revision - fallback 

### DIFF
--- a/tools/setup_services.py
+++ b/tools/setup_services.py
@@ -319,8 +319,18 @@ def git_checkout_plugin(url: str, rev: str, plugin_name: str, plugin_path: str) 
         clone_args = ["clone", "--depth", "1", url, f"--revision={rev}", plugin_path]
         try:
             run_git_command(clone_args, ".")
+            return True
         except RuntimeError:
-            return False
+            log(
+                f"Failed to clone external service {plugin_name} with --revision, trying without it for better compatibility with older git versions."
+            )
+            clone_args = ["clone", "--depth", "1", url, plugin_path]
+            try:
+                run_git_command(clone_args, ".")
+                return True
+            except RuntimeError as e:
+                log(f"Failed to clone external service {plugin_name}: {e}")
+                return False
 
     checkout_rev = get_rev(plugin_path)
     if checkout_rev == rev:
@@ -334,7 +344,8 @@ def git_checkout_plugin(url: str, rev: str, plugin_name: str, plugin_path: str) 
         # since it's a shallow clone, we need to fetch the specific SHA
         run_git_command(["fetch", "--depth=1", "origin", rev], plugin_path)
         run_git_command(["checkout", "FETCH_HEAD"], plugin_path)
-    except RuntimeError:
+    except RuntimeError as e:
+        log(f"Failed to checkout external service {plugin_name}: {e}")
         return False
 
     return True


### PR DESCRIPTION
add fallback to clone without --revision, if that flag isn't available for the version of `git` installed on the host (we ran into that issue in prod, where even recent versions of ubuntu, debian, ... have a version of `git` that's a little old and does not support this flag, while our dev machines on macos do hence why we never saw this commit).

I could have simply dropped the `--revision` flag altogether (since anyway we checkout to the right revision if need be, few lines after), but I like the idea of only copying over the exact revision needed when we first clone the repo, which is a bit less wasteful than clone + checkout. So, might as well try it and only if it doesn't work take the regular clone + checkout path (+ log that we ran into that fallback and why, to give folks a hint about their git version perhaps being a little old).