### PR TITLE
JS deps .sh scripts (updates & check), always use uv's python

### DIFF
--- a/tools/check_js_deps.sh
+++ b/tools/check_js_deps.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-INSTALLER=$(python baselayer/tools/get_js_installer.py)
+INSTALLER=$(PYTHONPATH=. uv run python baselayer/tools/get_js_installer.py)
 CHECKER="node_modules/.bin/check-dependencies"
 
 if [[ ! -x ${CHECKER} ]]; then

--- a/tools/check_js_updates.sh
+++ b/tools/check_js_updates.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export NPM_CHECK_INSTALLER=$(python baselayer/tools/get_js_installer.py)
+export NPM_CHECK_INSTALLER=$(PYTHONPATH=. uv run python baselayer/tools/get_js_installer.py)
 CHECKER="npx npm-check"
 
 if ( ! $CHECKER --version > /dev/null 2>&1 ); then


### PR DESCRIPTION
In this PR, we update 2 .sh scripts to use `PYTHONPATH=. uv run python` rather than just `python`, so it works whether or not one has entered the virtual env that was created by uv. I found that change quite useful because we that implemented, I can now just run `make run` in SkyPortal and my app starts, and I don't even need to think about entering my venv first!