### PR TITLE
pyproject.toml: specify package inclusion for setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,3 +44,6 @@ docs = [
     "sphinx>=9.1.0; python_version >= '3.12'",
     "sphinx-rtd-theme>=3.1.0",
 ]
+
+[tool.setuptools.packages.find]
+include = ["baselayer*"]


### PR DESCRIPTION
In Fritz, I am trying to install the dependencies of skyportal in my .venv. Turns out this got really annoying very quickly and I simply can't do it (without re-inventing the wheel) because baselayer and skyportal do not specify which of their folder contains the actual python code one may need, if it's added as a dependency.

This PR adds a quick fix for that, so I can run `uv pip install -r skyportal/pyproject.toml` upstream without everything breaking.