### PR TITLE
Improve makefile bundle management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ B=\033[1m
 # Normal
 N=\033[0m
 
-bundle = static/build/main.bundle.js
 rspack = npx rspack
 
 # NOTE: These targets are meant to be *included* in the parent app
@@ -35,7 +34,7 @@ rspack = npx rspack
 .PHONY: stop status test_headless test test_report check-js-updates lint-install
 .PHONY: lint lint-unix lint-githook baselayer_doc_reqs html
 .PHONY: system_setup service_setup
-.PHONY: $(bundle) bundle bundle-watch
+.PHONY: bundle bundle-watch
 
 help:
 	@python ./baselayer/tools/makefile_to_help.py $(MAKEFILE_LIST)
@@ -55,10 +54,8 @@ db_clear: ## Delete all data from the database.
 db_clear: dependencies
 	@$(PYTHON) ./baselayer/tools/silent_monitor.py ./baselayer/tools/db_init.py -f $(FLAGS)
 
-$(bundle): rspack.config.js package.json
+bundle:
 	@$(rspack)
-
-bundle: $(bundle)
 
 bundle-watch:
 	$(rspack) -w
@@ -126,7 +123,7 @@ attach: ## Attach to terminal of running webserver; useful to, e.g., use pdb.
 	@echo "$(SUPERVISORCTL) fg app:app_NN"
 
 clean:
-	rm -f $(bundle)
+	rm -rf static/build
 
 stop: ## Stop all running services.
 	$(SUPERVISORCTL) stop all

--- a/tools/setup_services.py
+++ b/tools/setup_services.py
@@ -399,7 +399,7 @@ def initialize_external_services() -> list:
     plugins_path = cfg["services.paths"][-1]
     os.makedirs(plugins_path, exist_ok=True)
 
-    plugins = cfg.get("services.external", {})
+    plugins = cfg.get("services.external") or {}
     external_services = []
 
     for plugin_name, plugin_info in plugins.items():

--- a/tools/test_frontend.py
+++ b/tools/test_frontend.py
@@ -65,8 +65,9 @@ def verify_server_availability(url, timeout=180):
                 f"Expected status 200, got {response.status_code} for URL {url}. Retrying."
             )
 
-            assert 'src="/static/build/' in response.text, (
-                "Javascript bundle not found in index.html, did packing fail?"
+            bundle_dir = pathlib.Path("static/build")
+            assert bundle_dir.exists() and any(bundle_dir.glob("main*.bundle.js")), (
+                "Javascript bundle not found in static/build/, did packing fail?"
             )
 
             return True  # all checks passed
@@ -131,7 +132,6 @@ if __name__ == "__main__":
     )
 
     server_url = f"http://localhost:{cfg['ports.app']}"
-    print()
     log(f"Waiting for server to appear at {server_url}...")
 
     exit_status = (0, "OK")

--- a/tools/test_frontend.py
+++ b/tools/test_frontend.py
@@ -65,9 +65,8 @@ def verify_server_availability(url, timeout=180):
                 f"Expected status 200, got {response.status_code} for URL {url}. Retrying."
             )
 
-            response = requests.get(url + "/static/build/main.bundle.js")
-            assert response.status_code == 200, (
-                "Javascript bundle not found, did packing fail?"
+            assert 'src="/static/build/' in response.text, (
+                "Javascript bundle not found in index.html, did packing fail?"
             )
 
             return True  # all checks passed


### PR DESCRIPTION
- Remove hardcoded bundle filename from Makefile to allow having content hashes in the main bundle name.
- Update frontend test to remove the hardcoded bundle name.
- simplify bundle targets

I have opened a PR (https://github.com/skyportal/skyportal/pull/6034) on SkyPortal to switch the bundle cache key to use a content hash instead of the skyportal version hash. As part of this, I also updated Baselayer to support hashed bundle filenames.