### PR TITLE
Allow the websocket message bus to bind a tcp:// address

### DIFF
--- a/app/flow.py
+++ b/app/flow.py
@@ -11,11 +11,15 @@ log = make_log("flow")
 class Flow:
     """Send messages through websocket to frontend"""
 
-    def __init__(self, socket_path=cfg["ports.websocket_path_in"]):
-        self._socket_path = socket_path
+    def __init__(
+        self,
+        host=cfg["hosts.message_bus"],
+        port=cfg["ports.message_bus_receive"],
+    ):
+        self._endpoint = f"tcp://{host}:{port}"
         self._ctx = zmq.Context.instance()
         self._bus = self._ctx.socket(zmq.PUSH)
-        self._bus.connect(self._socket_path)
+        self._bus.connect(self._endpoint)
 
     def push(self, user_id, action_type, payload={}):
         """Push action to specified user over websocket.

--- a/app/flow.py
+++ b/app/flow.py
@@ -9,8 +9,15 @@ log = make_log("flow")
 
 
 class Flow:
-    """Send messages through websocket to frontend"""
+    """Send messages through websocket to frontend
 
+    Parameters
+    ----------
+    host : str
+        Host on which the message proxy is running.
+    port : str
+        Port on which the message bus is listening for messages.
+    """
     def __init__(
         self,
         host=cfg["hosts.message_bus"],

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -134,8 +134,8 @@ ports:
     app_http_proxy: 5001
     app_internal: 65000  # nginx forwards this port to ports:app
     dask: 63500
-    message_bus_receive: 64002  # message_proxy binds; the app/workers push here
-    message_bus_publish: 64003  # message_proxy binds; the websocket server reads here
+    message_bus_receive: 64002  # bus listens for incoming messages here; app/clients push to this port
+    message_bus_publish: 64003  # bus sends out messages here; websocket server reads from this port
     status: 64500
     migration_manager: 64501
 

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -134,6 +134,8 @@ ports:
     app_http_proxy: 5001
     app_internal: 65000  # nginx forwards this port to ports:app
     dask: 63500
+    # ipc:// requires producers, the websocket server and message_proxy to share a host.
+    # For multi-host/k8s, use a routable address, e.g. tcp://message_proxy:64002.
     websocket_path_in: 'ipc://run/message_flow_in'
     websocket_path_out: 'ipc://run/message_flow_out'
     status: 64500

--- a/config.yaml.defaults
+++ b/config.yaml.defaults
@@ -134,12 +134,16 @@ ports:
     app_http_proxy: 5001
     app_internal: 65000  # nginx forwards this port to ports:app
     dask: 63500
-    # ipc:// requires producers, the websocket server and message_proxy to share a host.
-    # For multi-host/k8s, use a routable address, e.g. tcp://message_proxy:64002.
-    websocket_path_in: 'ipc://run/message_flow_in'
-    websocket_path_out: 'ipc://run/message_flow_out'
+    message_bus_receive: 64002  # message_proxy binds; the app/workers push here
+    message_bus_publish: 64003  # message_proxy binds; the websocket server reads here
     status: 64500
     migration_manager: 64501
+
+hosts:
+    # Host running the message bus (message_proxy). The app, workers and the
+    # websocket server connect to it over TCP, so set this to a routable address
+    # (e.g. a k8s Service name) when running the bus on a separate host/pod.
+    message_bus: 127.0.0.1
 
 external_logging:
     papertrail:

--- a/services/message_proxy/message_proxy.py
+++ b/services/message_proxy/message_proxy.py
@@ -9,7 +9,7 @@ env, cfg = load_env()
 
 log = make_log("message_proxy")
 
-# Bind on all interfaces so producers/consumers on other hosts can connect.
+# Bind on all interfaces so producers/consumers on other hosts can connect
 IN = f"tcp://*:{cfg['ports.message_bus_receive']}"
 OUT = f"tcp://*:{cfg['ports.message_bus_publish']}"
 

--- a/services/message_proxy/message_proxy.py
+++ b/services/message_proxy/message_proxy.py
@@ -12,13 +12,30 @@ log = make_log("message_proxy")
 IN = cfg["ports.websocket_path_in"]
 OUT = cfg["ports.websocket_path_out"]
 
+
+def bind_endpoint(endpoint):
+    """Convert a ZMQ *connect* endpoint into the matching *bind* endpoint.
+
+    ipc:// binds and connects to the same path (returned unchanged). tcp://
+    must bind all interfaces, so the host is replaced with the wildcard ``*``
+    while the port is kept (tcp://message_proxy:64002 -> tcp://*:64002).
+    """
+    if endpoint.startswith("tcp://"):
+        port = endpoint.rsplit(":", 1)[-1]
+        return f"tcp://*:{port}"
+    return endpoint
+
+
+IN_BIND = bind_endpoint(IN)
+OUT_BIND = bind_endpoint(OUT)
+
 context = zmq.Context()
 
 feed_in = context.socket(zmq.PULL)
-feed_in.bind(IN)
+feed_in.bind(IN_BIND)
 
 feed_out = context.socket(zmq.PUB)
-feed_out.bind(OUT)
+feed_out.bind(OUT_BIND)
 
-log(f"Forwarding messages between {IN} and {OUT}")
+log(f"Forwarding messages between {IN_BIND} and {OUT_BIND}")
 zmq.proxy(feed_in, feed_out)

--- a/services/message_proxy/message_proxy.py
+++ b/services/message_proxy/message_proxy.py
@@ -9,33 +9,17 @@ env, cfg = load_env()
 
 log = make_log("message_proxy")
 
-IN = cfg["ports.websocket_path_in"]
-OUT = cfg["ports.websocket_path_out"]
-
-
-def bind_endpoint(endpoint):
-    """Convert a ZMQ *connect* endpoint into the matching *bind* endpoint.
-
-    ipc:// binds and connects to the same path (returned unchanged). tcp://
-    must bind all interfaces, so the host is replaced with the wildcard ``*``
-    while the port is kept (tcp://message_proxy:64002 -> tcp://*:64002).
-    """
-    if endpoint.startswith("tcp://"):
-        port = endpoint.rsplit(":", 1)[-1]
-        return f"tcp://*:{port}"
-    return endpoint
-
-
-IN_BIND = bind_endpoint(IN)
-OUT_BIND = bind_endpoint(OUT)
+# Bind on all interfaces so producers/consumers on other hosts can connect.
+IN = f"tcp://*:{cfg['ports.message_bus_receive']}"
+OUT = f"tcp://*:{cfg['ports.message_bus_publish']}"
 
 context = zmq.Context()
 
 feed_in = context.socket(zmq.PULL)
-feed_in.bind(IN_BIND)
+feed_in.bind(IN)
 
 feed_out = context.socket(zmq.PUB)
-feed_out.bind(OUT_BIND)
+feed_out.bind(OUT)
 
-log(f"Forwarding messages between {IN_BIND} and {OUT_BIND}")
+log(f"Forwarding messages between {IN} and {OUT}")
 zmq.proxy(feed_in, feed_out)

--- a/services/websocket_server/websocket_server.py
+++ b/services/websocket_server/websocket_server.py
@@ -168,7 +168,9 @@ class WebSocket(websocket.WebSocketHandler):
 
 if __name__ == "__main__":
     PORT = cfg["ports.websocket"]
-    LOCAL_OUTPUT = cfg["ports.websocket_path_out"]
+    LOCAL_OUTPUT = (
+        f"tcp://{cfg['hosts.message_bus']}:{cfg['ports.message_bus_publish']}"
+    )
 
     import zmq
     from zmq.eventloop import zmqstream


### PR DESCRIPTION
This PR allows the websocket message bus to bind a tcp:// address (next step in Kubernetes readiness).