### PR TITLE
remove notedown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ test = [
     "pytest-playwright>=0.7.1",
 ]
 docs = [
-    "notedown>=1.5.1",
     "numpydoc>=1.10.0; python_version >= '3.12'",  # Can remove these tags once Sphinx supports all baselayer supported Python versions
     "recommonmark>=0.7.1",
     "sphinx>=9.1.0; python_version >= '3.12'",


### PR DESCRIPTION
This PR removes the unused notedown package (which pulls in the deprecated bleach package).