### PR TITLE
Fix security vuln in pyjwt version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "packaging>=23.0",
     "phonenumbers>=8.12.15",
     "psycopg[binary]>=3.2.0",
-    "pyjwt>=2.0.1",
+    "pyjwt>=2.13.0",
     "python-dateutil>=2.8.1",
     "python-slugify>=4.0.1",
     "pyyaml>=6.0.1",
@@ -22,7 +22,7 @@ dependencies = [
     "sqlalchemy-utils>=0.36.8",
     "supervisor>=4.3",
     "tomli >= 2.1.0; python_full_version < '3.11'",
-    "tornado>=6.0.3",
+    "tornado>=6.5.7",
 ]
 
 [tool.uv]


### PR DESCRIPTION
 Update dependencies: bump pyjwt to 2.13.0 to fix a security vulnerability and bump tornado to 6.5.7.