### PR TITLE
_resolve_pooler: force prepare_threshold=None over caller connect_args

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -340,8 +340,9 @@ def _resolve_pooler(host, port, engine_args, pooler):
         "pool_pre_ping": True,
         **engine_args,
         "connect_args": {
-            "prepare_threshold": None,
             **(engine_args.get("connect_args") or {}),
+            # Mandatory under transaction pooling; must override any caller value.
+            "prepare_threshold": None,
         },
     }
     return host, port, engine_args


### PR DESCRIPTION
This PR forces prepare_threshold=None over caller connect_args for _resolve_pooler.