### PR TITLE
fix ChunkLoadError from a stale cached index.html

### DIFF
--- a/app/handlers/mainpage.py
+++ b/app/handlers/mainpage.py
@@ -3,9 +3,7 @@ from baselayer.app.handlers.base import BaseHandler
 
 class MainPageHandler(BaseHandler):
     def get(self):
-        # Never cache the SPA shell: a stale copy points at bundle hashes that no
-        # longer exist after a rebuild, 404-ing lazy chunks (ChunkLoadError).
-        self.set_header("Cache-Control", "no-cache, no-store, must-revalidate")
+        self.set_header("Cache-Control", "no-cache")
         if not self.current_user:
             self.render("login.html")
         else:

--- a/app/handlers/mainpage.py
+++ b/app/handlers/mainpage.py
@@ -3,6 +3,9 @@ from baselayer.app.handlers.base import BaseHandler
 
 class MainPageHandler(BaseHandler):
     def get(self):
+        # Never cache the SPA shell: a stale copy points at bundle hashes that no
+        # longer exist after a rebuild, 404-ing lazy chunks (ChunkLoadError).
+        self.set_header("Cache-Control", "no-cache, no-store, must-revalidate")
         if not self.current_user:
             self.render("login.html")
         else:

--- a/services/nginx/nginx.conf.template
+++ b/services/nginx/nginx.conf.template
@@ -167,6 +167,11 @@ http {
       proxy_buffers 32 8k;
 
       # Serve static files directly
+      location /static/build/ {
+        root .;
+        include mime.types;
+        add_header Cache-Control "public, max-age=31536000, immutable";
+      }
       location /static/ {
         root .;
         include mime.types;


### PR DESCRIPTION
This PR serves the SPA shell with no-cache to avoid stale-bundle ChunkLoadError hangs.