### PR TITLE
Remove comment in fill_conf_values recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,6 @@ paths:
 	@mkdir -p ./log/sv_child
 
 fill_conf_values:
-	# -xdev keeps find on the source-tree filesystem, skipping mounted data
-	# volumes (e.g. cephfs thumbnails) that hold no templates but slow startup.
 	@find -L . -xdev -name '[^.]*.template' | grep -Ev "node_modules|doc|docs|.venv" | PYTHONPATH=. xargs uv run python ./baselayer/tools/fill_conf_values.py $(FLAGS)
 
 system_setup: | paths dependencies fill_conf_values service_setup


### PR DESCRIPTION
- Remove the two comment lines added above the `find` call in `fill_conf_values`
- They are recipe lines, so make echoes them on every run