### PR TITLE
On finish guard

### DIFF
--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -158,15 +158,9 @@ class PSABaseHandler(RequestHandler):
         try:
             DBSession.remove()
         except Exception as e:
-            # The response is already sent, so raising here does not surface to
-            # the client -- it lands in Tornado's error handling as "Exception
-            # in exception handler", masking the real outcome of the request.
-            #
-            # remove() rolls back, which fails when the server has already
-            # closed the connection: pgbouncer drops one that sat idle in a
-            # transaction past idle_transaction_timeout. Discard the session so
-            # the next request on this context starts clean rather than
-            # inheriting the dead one.
+            # The rollback in remove() fails if pgbouncer already closed the
+            # connection. The response is sent, so drop the session rather than
+            # raising into Tornado's error handling.
             log(f"Session cleanup failed, discarding it: {e}")
             try:
                 DBSession.registry.clear()

--- a/app/handlers/base.py
+++ b/app/handlers/base.py
@@ -155,7 +155,23 @@ class PSABaseHandler(RequestHandler):
             )
 
     def on_finish(self):
-        DBSession.remove()
+        try:
+            DBSession.remove()
+        except Exception as e:
+            # The response is already sent, so raising here does not surface to
+            # the client -- it lands in Tornado's error handling as "Exception
+            # in exception handler", masking the real outcome of the request.
+            #
+            # remove() rolls back, which fails when the server has already
+            # closed the connection: pgbouncer drops one that sat idle in a
+            # transaction past idle_transaction_timeout. Discard the session so
+            # the next request on this context starts clean rather than
+            # inheriting the dead one.
+            log(f"Session cleanup failed, discarding it: {e}")
+            try:
+                DBSession.registry.clear()
+            except Exception:
+                pass
 
 
 class BaseHandler(PSABaseHandler):


### PR DESCRIPTION
This PR stops a dead connection's rollback from raising out of on_finish (run into sometimes on Fritz).

@thomasculino @antoine-le-calloch