### PR TITLE
Return failed sign-ins to the login page instead of a 500

### DIFF
--- a/app/app_server.py
+++ b/app/app_server.py
@@ -25,7 +25,10 @@ settings = {
     "SOCIAL_AUTH_STRATEGY": "baselayer.app.psa.TornadoStrategy",
     "SOCIAL_AUTH_LOGIN_URL": "/",
     "SOCIAL_AUTH_LOGIN_REDIRECT_URL": "/",  # on success
-    "SOCIAL_AUTH_LOGIN_ERROR_URL": "/login-error/",
+    # Where a failed sign-in lands. Nothing serves /login-error/, so the
+    # default is the login page itself; an app with a dedicated page for
+    # this points the setting at it.
+    "SOCIAL_AUTH_LOGIN_ERROR_URL": "/",
     "SOCIAL_AUTH_USER_FIELDS": ["username"],
     "SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL": cfg.get(
         "server.auth.username_is_email", True

--- a/app/app_server.py
+++ b/app/app_server.py
@@ -25,9 +25,6 @@ settings = {
     "SOCIAL_AUTH_STRATEGY": "baselayer.app.psa.TornadoStrategy",
     "SOCIAL_AUTH_LOGIN_URL": "/",
     "SOCIAL_AUTH_LOGIN_REDIRECT_URL": "/",  # on success
-    # Where a failed sign-in lands. Nothing serves /login-error/, so the
-    # default is the login page itself; an app with a dedicated page for
-    # this points the setting at it.
     "SOCIAL_AUTH_LOGIN_ERROR_URL": "/",
     "SOCIAL_AUTH_USER_FIELDS": ["username"],
     "SOCIAL_AUTH_USERNAME_IS_FULL_EMAIL": cfg.get(

--- a/app/handlers/auth.py
+++ b/app/handlers/auth.py
@@ -3,10 +3,13 @@ from functools import wraps
 import tornado.web
 from social_core.actions import do_auth, do_complete, do_disconnect
 from social_core.backends.utils import get_backend
-from social_core.exceptions import MissingBackend
+from social_core.exceptions import AuthException, MissingBackend
 from social_core.utils import get_strategy, setting_name
 
 from baselayer.app.handlers.base import BaseHandler
+from baselayer.log import make_log
+
+log = make_log("auth")
 
 DEFAULTS = {
     "STORAGE": "baselayer.app.psa.TornadoStorage",
@@ -51,6 +54,19 @@ def psa(redirect_uri=None):
     return decorator
 
 
+def _failed(handler, backend, exc):
+    """Send the user back to sign in instead of showing them a traceback.
+
+    A failed OAuth exchange is nearly always the user's attempt going stale --
+    an authorization code already spent, a consent screen dismissed, a provider
+    briefly refusing the token request -- rather than a fault in this
+    application. Raising turns that into a 500 and an error report; log it and
+    let them try again.
+    """
+    log(f"Authentication with {backend} failed: {exc}")
+    handler.redirect(handler.settings.get("SOCIAL_AUTH_LOGIN_ERROR_URL", "/"))
+
+
 class AuthHandler(BaseHandler):
     def get(self, backend):
         self._auth(backend)
@@ -60,7 +76,10 @@ class AuthHandler(BaseHandler):
 
     @psa("complete")
     def _auth(self, backend):
-        do_auth(self.backend)
+        try:
+            do_auth(self.backend)
+        except AuthException as e:
+            _failed(self, backend, e)
 
 
 class CompleteHandler(BaseHandler):
@@ -72,11 +91,14 @@ class CompleteHandler(BaseHandler):
 
     @psa("complete")
     def _complete(self, backend):
-        do_complete(
-            self.backend,
-            login=lambda backend, user, social_user: self.login_user(user),
-            user=self._signed_in_user(),
-        )
+        try:
+            do_complete(
+                self.backend,
+                login=lambda backend, user, social_user: self.login_user(user),
+                user=self._signed_in_user(),
+            )
+        except AuthException as e:
+            _failed(self, backend, e)
 
 
 class DisconnectHandler(BaseHandler):

--- a/app/handlers/auth.py
+++ b/app/handlers/auth.py
@@ -55,14 +55,7 @@ def psa(redirect_uri=None):
 
 
 def _failed(handler, backend, exc):
-    """Send the user back to sign in instead of showing them a traceback.
-
-    A failed OAuth exchange is nearly always the user's attempt going stale --
-    an authorization code already spent, a consent screen dismissed, a provider
-    briefly refusing the token request -- rather than a fault in this
-    application. Raising turns that into a 500 and an error report; log it and
-    let them try again.
-    """
+    # Almost always user-side (spent code, dismissed consent), not a server fault.
     log(f"Authentication with {backend} failed: {exc}")
     handler.redirect(handler.settings.get("SOCIAL_AUTH_LOGIN_ERROR_URL", "/"))
 


### PR DESCRIPTION
This PR returns failed sign-ins to the login page instead of a 500.